### PR TITLE
NAN-397: Add Google OAuth login via BetterAuth

### DIFF
--- a/src/app/api/auth/providers/route.ts
+++ b/src/app/api/auth/providers/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  const google = !!(
+    process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+  )
+
+  return NextResponse.json({ google })
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
@@ -17,6 +17,29 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}
+
 export function LoginForm({
   className,
   ...props
@@ -25,7 +48,22 @@ export function LoginForm({
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false)
+  const [isGoogleEnabled, setIsGoogleEnabled] = useState(false)
   const router = useRouter()
+
+  useEffect(() => {
+    async function fetchProviders() {
+      try {
+        const res = await fetch('/api/auth/providers')
+        const data = await res.json()
+        setIsGoogleEnabled(data.google === true)
+      } catch {
+        // If the fetch fails, just don't show Google button
+      }
+    }
+    fetchProviders()
+  }, [])
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -44,6 +82,16 @@ export function LoginForm({
     }
 
     router.push('/dashboard')
+  }
+
+  async function handleGoogleLogin() {
+    setIsGoogleLoading(true)
+    setError(null)
+
+    await authClient.signIn.social({
+      provider: 'google',
+      callbackURL: '/dashboard',
+    })
   }
 
   return (
@@ -84,16 +132,42 @@ export function LoginForm({
                 {isLoading ? 'Logging in...' : 'Login'}
               </Button>
             </div>
-            <div className="mt-4 text-center text-sm">
-              Don&apos;t have an account?{' '}
-              <Link
-                href="/auth/sign-up"
-                className="underline underline-offset-4"
-              >
-                Sign up
-              </Link>
-            </div>
           </form>
+          {isGoogleEnabled && (
+            <>
+              <div className="relative my-6">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">
+                    or
+                  </span>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                disabled={isGoogleLoading}
+                onClick={handleGoogleLogin}
+              >
+                <GoogleIcon />
+                {isGoogleLoading
+                  ? 'Redirecting...'
+                  : 'Sign in with Google'}
+              </Button>
+            </>
+          )}
+          <div className="mt-4 text-center text-sm">
+            Don&apos;t have an account?{' '}
+            <Link
+              href="/auth/sign-up"
+              className="underline underline-offset-4"
+            >
+              Sign up
+            </Link>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/auth/sign-up-form.tsx
+++ b/src/components/auth/sign-up-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
@@ -17,6 +17,29 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}
+
 export function SignUpForm({
   className,
   ...props
@@ -27,7 +50,22 @@ export function SignUpForm({
   const [repeatPassword, setRepeatPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false)
+  const [isGoogleEnabled, setIsGoogleEnabled] = useState(false)
   const router = useRouter()
+
+  useEffect(() => {
+    async function fetchProviders() {
+      try {
+        const res = await fetch('/api/auth/providers')
+        const data = await res.json()
+        setIsGoogleEnabled(data.google === true)
+      } catch {
+        // If the fetch fails, just don't show Google button
+      }
+    }
+    fetchProviders()
+  }, [])
 
   async function handleSignUp(e: React.FormEvent) {
     e.preventDefault()
@@ -53,6 +91,16 @@ export function SignUpForm({
     }
 
     router.push('/dashboard')
+  }
+
+  async function handleGoogleSignUp() {
+    setIsGoogleLoading(true)
+    setError(null)
+
+    await authClient.signIn.social({
+      provider: 'google',
+      callbackURL: '/dashboard',
+    })
   }
 
   return (
@@ -112,13 +160,39 @@ export function SignUpForm({
                 {isLoading ? 'Creating account...' : 'Sign up'}
               </Button>
             </div>
-            <div className="mt-4 text-center text-sm">
-              Already have an account?{' '}
-              <Link href="/auth/login" className="underline underline-offset-4">
-                Login
-              </Link>
-            </div>
           </form>
+          {isGoogleEnabled && (
+            <>
+              <div className="relative my-6">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">
+                    or
+                  </span>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                disabled={isGoogleLoading}
+                onClick={handleGoogleSignUp}
+              >
+                <GoogleIcon />
+                {isGoogleLoading
+                  ? 'Redirecting...'
+                  : 'Sign up with Google'}
+              </Button>
+            </>
+          )}
+          <div className="mt-4 text-center text-sm">
+            Already have an account?{' '}
+            <Link href="/auth/login" className="underline underline-offset-4">
+              Login
+            </Link>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,10 @@ import { nextCookies } from 'better-auth/next-js'
 
 import { prisma } from '@/lib/prisma'
 
+const googleClientId = process.env.GOOGLE_CLIENT_ID
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET
+const isGoogleEnabled = !!(googleClientId && googleClientSecret)
+
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: 'sqlite',
@@ -14,6 +18,15 @@ export const auth = betterAuth({
     minPasswordLength: 8,
     maxPasswordLength: 128,
   },
+
+  ...(isGoogleEnabled && {
+    socialProviders: {
+      google: {
+        clientId: googleClientId!,
+        clientSecret: googleClientSecret!,
+      },
+    },
+  }),
 
   session: {
     expiresIn: 60 * 60 * 24 * 7,


### PR DESCRIPTION
## Summary
- Add Google OAuth social login to BetterAuth config (conditionally enabled when `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` env vars are set)
- Add `/api/auth/providers` endpoint to expose available auth providers to the client
- Add "Sign in with Google" / "Sign up with Google" buttons to login and sign-up forms with Google "G" logo
- Buttons only render when Google auth is configured — graceful degradation for self-hosted users

## Test plan
- [x] Without env vars: Google button hidden, `/api/auth/providers` returns `{ google: false }`
- [x] With env vars set: Google button visible with proper styling and "OR" divider
- [x] Sign-up page also shows "Sign up with Google" button
- [x] Existing email/password login unchanged
- [x] No Prisma schema changes needed (Account model already supports OAuth)

Closes NAN-397

🤖 Generated with [Claude Code](https://claude.com/claude-code)