### PR TITLE
NAN-399: Add settings tools to AI chat

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { convertToModelMessages, streamText, UIMessage, stepCountIs } from 'ai'
 import { openai } from '@ai-sdk/openai'
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
 import { buildSystemPrompt } from '@/lib/chat/system-prompt'
 import { createChatTools } from '@/lib/chat/tools'
 
@@ -15,11 +16,18 @@ export async function POST(request: Request) {
 
   const { messages }: { messages: UIMessage[] } = await request.json()
 
-  const systemPrompt = buildSystemPrompt()
+  const settings = await prisma.userSettings.findUnique({
+    where: { userId: session.user.id },
+  })
+
+  const modelId = settings?.aiModel ?? 'openai/gpt-4o-mini'
+  const openaiModelId = modelId.replace('openai/', '')
+
+  const systemPrompt = buildSystemPrompt(settings?.aiContext)
   const tools = createChatTools(session.user.id)
 
   const result = streamText({
-    model: openai('gpt-4o-mini'),
+    model: openai(openaiModelId),
     system: systemPrompt,
     messages: await convertToModelMessages(messages),
     tools,

--- a/src/lib/chat/system-prompt.ts
+++ b/src/lib/chat/system-prompt.ts
@@ -17,6 +17,8 @@ Today is ${today}. Use this to interpret relative date references like "last mon
 - **get_account_summary**: Get summary of all bank accounts with latest balances
 - **get_cashflow**: Get cashflow data for a date range
 - **get_category_breakdown**: Get spending breakdown by category
+- **get_settings**: Read the user's current settings (fiscal year, timezone, AI model, personal context)
+- **update_settings**: Update user settings — fiscal year end (month 1-12, day 1-31), timezones (IANA format), AI model ("openai/gpt-4o-mini" or "openai/gpt-4o"), personal context
 
 ## Guidelines
 1. Always use tools to find specific data — don't guess or make up numbers


### PR DESCRIPTION
## Summary
- Add `get_settings` and `update_settings` tools to the AI chat, enabling users to read and modify their settings via natural language
- Chat API now loads user settings and uses their configured AI model (was hardcoded to gpt-4o-mini)
- User's personal context is now passed to the system prompt for better AI responses
- System prompt updated to document the new settings tools

## Changes
- `src/lib/chat/tools.ts` — Added `get_settings` (read current settings) and `update_settings` (modify settings with validation) tools
- `src/lib/chat/system-prompt.ts` — Documented new tools in the Available Tools section
- `src/app/api/chat/route.ts` — Load user settings, use configured AI model, pass personal context to system prompt

## Test plan
- [x] "What are my current settings?" calls get_settings and returns defaults
- [x] "Change my fiscal year end to March 31 and set timezone to Eastern" calls update_settings successfully
- [x] Settings page reflects changes made via chat
- [x] Invalid AI model values are rejected with clear error message
- [x] Chat uses user's configured AI model instead of hardcoded default

Closes NAN-399

🤖 Generated with [Claude Code](https://claude.com/claude-code)