### PR TITLE
feat: show real user avatar in navbar and chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/react": "^3.0.99",
     "@prisma/adapter-better-sqlite3": "^7.4.1",
     "@prisma/client": "^7.4.1",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.1.0",
     "@radix-ui/react-label": "^2.1.0",

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -3,7 +3,9 @@
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport } from 'ai'
 import { useState, useRef, useEffect } from 'react'
-import { Send, Bot, User, Loader2, Sparkles } from 'lucide-react'
+import { Send, Bot, Loader2, Sparkles } from 'lucide-react'
+import { useSession } from '@/lib/auth-client'
+import { UserAvatar } from '@/components/user-avatar'
 
 function MarkdownContent({ text }: { text: string }) {
   const lines = text.split('\n')
@@ -88,6 +90,7 @@ const SUGGESTIONS = [
 ]
 
 export function ChatInterface() {
+  const { data: session } = useSession()
   const [input, setInput] = useState('')
   const { messages, sendMessage, status } = useChat({
     transport: new DefaultChatTransport({ api: '/api/chat' }),
@@ -184,9 +187,10 @@ export function ChatInterface() {
                   })}
                 </div>
                 {message.role === 'user' && (
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200">
-                    <User className="h-4 w-4 text-gray-600" />
-                  </div>
+                  <UserAvatar
+                    name={session?.user?.name}
+                    image={session?.user?.image}
+                  />
                 )}
               </div>
             ))}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -15,8 +15,9 @@ import {
 } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
-import { authClient } from '@/lib/auth-client'
+import { authClient, useSession } from '@/lib/auth-client'
 import { Button } from '@/components/ui/button'
+import { UserAvatar } from '@/components/user-avatar'
 
 const navItems = [
   { href: '/dashboard', label: 'Home', icon: Home },
@@ -28,6 +29,7 @@ const navItems = [
 export function Navbar() {
   const pathname = usePathname()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const { data: session } = useSession()
 
   async function handleSignOut() {
     await authClient.signOut()
@@ -89,16 +91,12 @@ export function Navbar() {
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              className="text-gray-600 hover:text-gray-900"
-            >
-              <Link href="/settings">
-                <Settings className="h-4 w-4" />
-              </Link>
-            </Button>
+            <Link href="/settings" className="rounded-full transition-opacity hover:opacity-80">
+              <UserAvatar
+                name={session?.user?.name}
+                image={session?.user?.image}
+              />
+            </Link>
             <Button
               variant="ghost"
               size="sm"

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import * as React from 'react'
+import * as AvatarPrimitive from '@radix-ui/react-avatar'
+
+import { cn } from '@/lib/utils'
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        'relative flex size-8 shrink-0 overflow-hidden rounded-full',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('aspect-square size-full', className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'flex size-full items-center justify-center rounded-full bg-muted',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Avatar, AvatarFallback, AvatarImage }

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { cn } from '@/lib/utils'
+
+interface UserAvatarProps {
+  name: string | null | undefined
+  image: string | null | undefined
+  className?: string
+}
+
+function getInitials(name: string | null | undefined): string {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 1) return parts[0][0].toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export function UserAvatar({ name, image, className }: UserAvatarProps) {
+  return (
+    <Avatar className={cn('h-8 w-8', className)}>
+      {image && <AvatarImage src={image} alt={name || 'User'} />}
+      <AvatarFallback className="bg-gray-200 text-xs font-medium text-gray-600">
+        {getInitials(name)}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,6 +1219,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-avatar@npm:^1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-avatar@npm:1.1.11"
+  dependencies:
+    "@radix-ui/react-context": "npm:1.1.3"
+    "@radix-ui/react-primitive": "npm:2.1.4"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+    "@radix-ui/react-use-is-hydrated": "npm:0.1.0"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: b1b3d4b11a8e05a8479d2410fb4e7b1bf825135c4cd42f7e5152568a54a55a3073bd87d50325150417a29306e7b1b371289dc3c4f11739af8a2a7bb8dd7c38c9
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-collection@npm:1.1.7":
   version: 1.1.7
   resolution: "@radix-ui/react-collection@npm:1.1.7"
@@ -1264,6 +1287,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: cece731f8cc25d494c6589cc681e5c01a93867d895c75889973afa1a255f163c286e390baa7bc028858eaabe9f6b57270d0ca6377356f652c5557c1c7a41ccce
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-context@npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0f271b4100dbb007ad2675f2529453f07454f214b7ce796d72680bf2dff050d0719083ee6e8962919a74048ff853eff2e50de07d8f8c674d6be91bfa76204cc2
   languageName: node
   linkType: hard
 
@@ -1722,6 +1758,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: bff53be99e940fef1d3c4df7d560e1d9133182e5a98336255d3063327d1d3dd4ec54a95dc5afe15cca4fb6c184f0a956c70de2815578c318cf995a7f9beabaa1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-is-hydrated@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/react-use-is-hydrated@npm:0.1.0"
+  dependencies:
+    use-sync-external-store: "npm:^1.5.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 635079bafe32829fc7405895154568ea94a22689b170489fd6d77668e4885e72ff71ed6d0ea3d602852841ef0f1927aa400fee2178d5dfbeb8bc9297da7d6498
   languageName: node
   linkType: hard
 
@@ -5759,6 +5810,7 @@ __metadata:
     "@playwright/test": "npm:^1.58.2"
     "@prisma/adapter-better-sqlite3": "npm:^7.4.1"
     "@prisma/client": "npm:^7.4.1"
+    "@radix-ui/react-avatar": "npm:^1.1.11"
     "@radix-ui/react-dialog": "npm:^1.1.0"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.0"
     "@radix-ui/react-label": "npm:^2.1.0"
@@ -7384,7 +7436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.6.0":
+"use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:


### PR DESCRIPTION
## Summary
- Replace generic placeholder icons with user's actual profile picture (from Google OAuth) or initials as fallback
- Add shadcn/ui Avatar component and reusable UserAvatar component
- Navbar shows user avatar linking to settings; chat shows real avatar next to user messages

## Test plan
- [ ] Log in with Google OAuth — verify avatar shows profile picture in navbar and chat
- [ ] Log in with email/password — verify initials fallback displays correctly
- [ ] Verify mobile menu still shows Settings icon (not avatar)

Closes NAN-401

🤖 Generated with [Claude Code](https://claude.com/claude-code)