### PR TITLE
feat: add OpenRouter support with Cerebras for fast AI chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DEPLOY_HOST=
 # OpenAI (for AI features — statement processing, categorization)
 OPENAI_API_KEY="sk-..."
 
+# OpenRouter (for fast AI chat via Cerebras, Gemini, and other models)
+OPENROUTER_API_KEY=""
+
 # BetterAuth
 BETTER_AUTH_SECRET=""
 BETTER_AUTH_URL="http://localhost:3000"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.30",
     "@ai-sdk/react": "^3.0.99",
+    "@openrouter/ai-sdk-provider": "^2.2.3",
     "@prisma/adapter-better-sqlite3": "^7.4.1",
     "@prisma/client": "^7.4.1",
     "@radix-ui/react-dialog": "^1.1.0",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { convertToModelMessages, streamText, UIMessage, stepCountIs } from 'ai'
 import { openai } from '@ai-sdk/openai'
+import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { prisma } from '@/lib/prisma'
@@ -7,6 +8,18 @@ import { buildSystemPrompt } from '@/lib/chat/system-prompt'
 import { createChatTools } from '@/lib/chat/tools'
 
 export const maxDuration = 60
+
+function getModel(modelId: string) {
+  if (modelId.startsWith('openrouter/')) {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })
+    return openrouter(modelId.replace('openrouter/', ''))
+  }
+
+  const openaiModelId = modelId.replace('openai/', '')
+  return openai(openaiModelId)
+}
 
 export async function POST(request: Request) {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -20,14 +33,13 @@ export async function POST(request: Request) {
     where: { userId: session.user.id },
   })
 
-  const modelId = settings?.aiModel ?? 'openai/gpt-4o-mini'
-  const openaiModelId = modelId.replace('openai/', '')
+  const modelId = settings?.aiModel ?? 'openrouter/cerebras/auto'
 
   const systemPrompt = buildSystemPrompt(settings?.aiContext)
   const tools = createChatTools(session.user.id)
 
   const result = streamText({
-    model: openai(openaiModelId),
+    model: getModel(modelId),
     system: systemPrompt,
     messages: await convertToModelMessages(messages),
     tools,

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -214,8 +214,14 @@ export function SettingsForm({ settings: initial, accounts: initialAccounts }: S
               onChange={e => setSettings(prev => ({ ...prev, aiModel: e.target.value }))}
               className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm"
             >
-              <option value="openai/gpt-4o-mini">GPT-4o Mini (default)</option>
-              <option value="openai/gpt-4o">GPT-4o</option>
+              <optgroup label="OpenRouter">
+                <option value="openrouter/cerebras/auto">Cerebras Auto (fastest)</option>
+                <option value="openrouter/google/gemini-2.5-flash-preview">Gemini 2.5 Flash</option>
+              </optgroup>
+              <optgroup label="OpenAI">
+                <option value="openai/gpt-4o-mini">GPT-4o Mini</option>
+                <option value="openai/gpt-4o">GPT-4o</option>
+              </optgroup>
             </select>
           </div>
           <div>

--- a/src/lib/chat/tools.ts
+++ b/src/lib/chat/tools.ts
@@ -231,13 +231,13 @@ export function createChatTools(userId: string) {
     }),
 
     update_settings: tool({
-      description: 'Update user settings. Only pass the fields you want to change. Valid AI models: "openai/gpt-4o-mini", "openai/gpt-4o". Fiscal year end month is 1-12. Timezones use IANA format (e.g. "America/Toronto").',
+      description: 'Update user settings. Only pass the fields you want to change. Valid AI models: "openai/gpt-4o-mini", "openai/gpt-4o", "openrouter/cerebras/auto", "openrouter/google/gemini-2.5-flash-preview". Fiscal year end month is 1-12. Timezones use IANA format (e.g. "America/Toronto").',
       inputSchema: z.object({
         fiscalYearEndMonth: z.number().min(1).max(12).optional().describe('Fiscal year end month (1=January, 12=December)'),
         fiscalYearEndDay: z.number().min(1).max(31).optional().describe('Fiscal year end day'),
         bankTimezone: z.string().optional().describe('Bank timezone in IANA format (e.g. America/Vancouver)'),
         userTimezone: z.string().optional().describe('Display timezone in IANA format (e.g. America/Toronto)'),
-        aiModel: z.string().optional().describe('AI model: "openai/gpt-4o-mini" or "openai/gpt-4o"'),
+        aiModel: z.string().optional().describe('AI model identifier (e.g. "openrouter/cerebras/auto", "openai/gpt-4o-mini")'),
         aiContext: z.string().optional().describe('Personal context about the user for better AI responses'),
       }),
       execute: async (params) => {
@@ -248,8 +248,14 @@ export function createChatTools(userId: string) {
           if (params.bankTimezone !== undefined) data.bankTimezone = params.bankTimezone
           if (params.userTimezone !== undefined) data.userTimezone = params.userTimezone
           if (params.aiModel !== undefined) {
-            if (!['openai/gpt-4o-mini', 'openai/gpt-4o'].includes(params.aiModel)) {
-              return { error: 'Invalid AI model. Must be "openai/gpt-4o-mini" or "openai/gpt-4o".' }
+            const validModels = [
+              'openai/gpt-4o-mini',
+              'openai/gpt-4o',
+              'openrouter/cerebras/auto',
+              'openrouter/google/gemini-2.5-flash-preview',
+            ]
+            if (!validModels.includes(params.aiModel)) {
+              return { error: `Invalid AI model. Must be one of: ${validModels.join(', ')}` }
             }
             data.aiModel = params.aiModel
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openrouter/ai-sdk-provider@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "@openrouter/ai-sdk-provider@npm:2.2.3"
+  peerDependencies:
+    ai: ^6.0.0
+    zod: ^3.25.0 || ^4.0.0
+  checksum: d3b6cb9a8bc4df4c22ccbff13932ef25b3999b74abe9aa38d0d9de9e7ae6f69f4b0b6129c9ad13a0f901f068d4e67b7e8ce69a5cf63187bdb4c85608e359f149
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api@npm:1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
@@ -5756,6 +5766,7 @@ __metadata:
   dependencies:
     "@ai-sdk/openai": "npm:^3.0.30"
     "@ai-sdk/react": "npm:^3.0.99"
+    "@openrouter/ai-sdk-provider": "npm:^2.2.3"
     "@playwright/test": "npm:^1.58.2"
     "@prisma/adapter-better-sqlite3": "npm:^7.4.1"
     "@prisma/client": "npm:^7.4.1"


### PR DESCRIPTION
## Summary
- Add OpenRouter as an AI provider alongside OpenAI using `@openrouter/ai-sdk-provider`
- Default model changed to `openrouter/cerebras/auto` for maximum inference speed
- Settings UI updated with grouped model options: OpenRouter (Cerebras Auto, Gemini 2.5 Flash) and OpenAI (GPT-4o Mini, GPT-4o)
- Chat tools validation updated to accept new model identifiers

## Setup
Requires `OPENROUTER_API_KEY` environment variable (added to `.env.example`)

## Test plan
- [ ] Set `OPENROUTER_API_KEY` in env and verify Cerebras model streams responses quickly
- [ ] Switch between models in settings and verify chat uses the selected model
- [ ] Verify AI can change model via chat tool ("switch to GPT-4o")
- [ ] Verify OpenAI models still work when selected

Closes NAN-402

🤖 Generated with [Claude Code](https://claude.com/claude-code)