### PR TITLE
feat: make chat the primary home page

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -68,8 +68,8 @@ test.describe('Auth Flow', () => {
     await page.getByLabel('Repeat Password').fill(TEST_USER.password)
     await page.getByRole('button', { name: 'Sign up', exact: true }).click()
 
-    // Should redirect to dashboard after sign up
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 })
+    // Should redirect to chat after sign up
+    await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 })
     await expect(page.getByText('OpenFinance')).toBeVisible()
 
     // Sign out
@@ -81,7 +81,7 @@ test.describe('Auth Flow', () => {
     await page.getByLabel('Password').fill(TEST_USER.password)
     await page.getByRole('button', { name: 'Login' }).click()
 
-    // Should redirect to dashboard after login
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 })
+    // Should redirect to chat after login
+    await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 })
   })
 })

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -25,8 +25,8 @@ test.describe('Dashboard', () => {
     await page.goto('/dashboard')
 
     await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Transactions' })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Statements' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Chat' })).toBeVisible()
   })
 })

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -5,7 +5,7 @@ const AUTH_PASSWORD = 'E2eTestPass123!'
 const AUTH_NAME = 'E2E Test User'
 
 export async function ensureLoggedIn(page: Page) {
-  await page.goto('/dashboard')
+  await page.goto('/chat')
 
   // If redirected to login, create account or log in
   if (page.url().includes('/auth/login')) {
@@ -27,6 +27,6 @@ export async function ensureLoggedIn(page: Page) {
       await page.getByRole('button', { name: 'Sign up', exact: true }).click()
     }
 
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 })
+    await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 })
   }
 }

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -18,8 +18,9 @@ test.describe('Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Statements' })).toBeVisible()
   })
 
-  test('can navigate to chat page', async ({ page }) => {
-    await page.getByRole('link', { name: 'Chat' }).click()
+  test('can navigate to chat page via Home link', async ({ page }) => {
+    await page.goto('/dashboard')
+    await page.getByRole('link', { name: 'Home' }).click()
     await expect(page).toHaveURL(/\/chat/)
   })
 
@@ -29,9 +30,8 @@ test.describe('Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
   })
 
-  test('can navigate back to dashboard from any page', async ({ page }) => {
-    await page.goto('/transactions')
-    await page.getByRole('link', { name: 'Home' }).click()
+  test('can navigate to dashboard page', async ({ page }) => {
+    await page.getByRole('link', { name: 'Dashboard' }).click()
     await expect(page).toHaveURL(/\/dashboard/)
   })
 })

--- a/e2e/production.spec.ts
+++ b/e2e/production.spec.ts
@@ -32,8 +32,8 @@ test.describe('Production Deployment', () => {
     await page.getByLabel('Repeat Password').fill(prodPassword)
     await page.getByRole('button', { name: 'Sign up', exact: true }).click()
 
-    // Should arrive at dashboard
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 })
+    // Should arrive at chat (home page)
+    await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 })
     await expect(page.getByText('OpenFinance')).toBeVisible()
 
     // Navigate to each page
@@ -43,7 +43,7 @@ test.describe('Production Deployment', () => {
     await page.getByRole('link', { name: 'Statements' }).click()
     await expect(page).toHaveURL(/\/statements/)
 
-    await page.getByRole('link', { name: 'Chat' }).click()
+    await page.getByRole('link', { name: 'Home' }).click()
     await expect(page).toHaveURL(/\/chat/)
 
     await page.goto(`${PROD_URL}/settings`)

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -81,7 +81,7 @@ export function LoginForm({
       return
     }
 
-    router.push('/dashboard')
+    router.push('/chat')
   }
 
   async function handleGoogleLogin() {
@@ -90,7 +90,7 @@ export function LoginForm({
 
     await authClient.signIn.social({
       provider: 'google',
-      callbackURL: '/dashboard',
+      callbackURL: '/chat',
     })
   }
 

--- a/src/components/auth/sign-up-form.tsx
+++ b/src/components/auth/sign-up-form.tsx
@@ -90,7 +90,7 @@ export function SignUpForm({
       return
     }
 
-    router.push('/dashboard')
+    router.push('/chat')
   }
 
   async function handleGoogleSignUp() {
@@ -99,7 +99,7 @@ export function SignUpForm({
 
     await authClient.signIn.social({
       provider: 'google',
-      callbackURL: '/dashboard',
+      callbackURL: '/chat',
     })
   }
 

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -20,10 +20,10 @@ import { Button } from '@/components/ui/button'
 import { UserAvatar } from '@/components/user-avatar'
 
 const navItems = [
-  { href: '/dashboard', label: 'Home', icon: Home },
+  { href: '/chat', label: 'Home', icon: MessageSquare },
+  { href: '/dashboard', label: 'Dashboard', icon: Home },
   { href: '/transactions', label: 'Transactions', icon: Receipt },
   { href: '/statements', label: 'Statements', icon: FileText },
-  { href: '/chat', label: 'Chat', icon: MessageSquare },
 ]
 
 export function Navbar() {
@@ -60,7 +60,7 @@ export function Navbar() {
             </button>
             <div className="flex shrink-0 items-center">
               <Link
-                href="/dashboard"
+                href="/chat"
                 className="flex items-center gap-2"
               >
                 <span className="text-xl font-semibold text-gray-900 font-heading">


### PR DESCRIPTION
## Summary
- Reorder nav: Chat (now "Home") is first, Dashboard second
- Post-login redirect changed from `/dashboard` to `/chat`
- Logo link updated to point to `/chat`
- All e2e tests updated to match new navigation order

## Test plan
- [ ] After login, user lands on `/chat` (not `/dashboard`)
- [ ] Nav order: Home (chat), Dashboard, Transactions, Statements
- [ ] Logo click goes to chat
- [ ] Google OAuth callback lands on chat
- [ ] E2e tests pass

Closes NAN-405

🤖 Generated with [Claude Code](https://claude.com/claude-code)