### PR TITLE
feat: persist chat conversations to database

### DIFF
--- a/src/app/(private)/chat/page.tsx
+++ b/src/app/(private)/chat/page.tsx
@@ -1,11 +1,44 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
 import { ChatInterface } from '@/components/chat/chat-interface'
 
 export default async function ChatPage() {
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) redirect('/auth/login')
 
-  return <ChatInterface />
+  let thread = await prisma.chatThread.findFirst({
+    where: { userId: session.user.id, isArchived: false },
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!thread) {
+    thread = await prisma.chatThread.create({
+      data: { userId: session.user.id },
+      include: {
+        messages: {
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    })
+  }
+
+  const initialMessages = thread.messages.map(m => ({
+    id: m.id,
+    role: m.role as 'user' | 'assistant',
+    parts: [{ type: 'text' as const, text: m.content }],
+  }))
+
+  return (
+    <ChatInterface
+      threadId={thread.id}
+      initialMessages={initialMessages}
+    />
+  )
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -21,13 +21,20 @@ function getModel(modelId: string) {
   return openai(openaiModelId)
 }
 
+function extractTextContent(message: UIMessage): string {
+  return message.parts
+    ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+    .map(p => p.text)
+    .join('\n') ?? ''
+}
+
 export async function POST(request: Request) {
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
   }
 
-  const { messages }: { messages: UIMessage[] } = await request.json()
+  const { messages, threadId }: { messages: UIMessage[]; threadId?: string } = await request.json()
 
   const settings = await prisma.userSettings.findUnique({
     where: { userId: session.user.id },
@@ -38,12 +45,49 @@ export async function POST(request: Request) {
   const systemPrompt = buildSystemPrompt(settings?.aiContext)
   const tools = createChatTools(session.user.id)
 
+  // Save user message to DB if we have a thread
+  if (threadId) {
+    const lastUserMessage = messages.filter(m => m.role === 'user').pop()
+    if (lastUserMessage) {
+      const content = extractTextContent(lastUserMessage)
+
+      // Upsert to handle potential retries with the same message ID
+      await prisma.chatMessage.upsert({
+        where: { id: lastUserMessage.id },
+        create: {
+          id: lastUserMessage.id,
+          threadId,
+          role: 'user',
+          content,
+        },
+        update: {},
+      })
+
+      await prisma.chatThread.update({
+        where: { id: threadId },
+        data: { updatedAt: new Date() },
+      })
+    }
+  }
+
   const result = streamText({
     model: getModel(modelId),
     system: systemPrompt,
     messages: await convertToModelMessages(messages),
     tools,
     stopWhen: stepCountIs(5),
+    onFinish: async ({ text }) => {
+      if (threadId && text) {
+        await prisma.chatMessage.create({
+          data: {
+            threadId,
+            role: 'assistant',
+            content: text,
+            model: modelId,
+          },
+        })
+      }
+    },
   })
 
   return result.toUIMessageStreamResponse()

--- a/src/app/api/chat/threads/route.ts
+++ b/src/app/api/chat/threads/route.ts
@@ -1,0 +1,63 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+  }
+
+  let thread = await prisma.chatThread.findFirst({
+    where: { userId: session.user.id, isArchived: false },
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!thread) {
+    thread = await prisma.chatThread.create({
+      data: { userId: session.user.id },
+      include: {
+        messages: {
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    })
+  }
+
+  return Response.json({
+    threadId: thread.id,
+    messages: thread.messages.map(m => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      createdAt: m.createdAt,
+    })),
+  })
+}
+
+export async function POST() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+  }
+
+  await prisma.chatThread.updateMany({
+    where: { userId: session.user.id, isArchived: false },
+    data: { isArchived: true },
+  })
+
+  const thread = await prisma.chatThread.create({
+    data: { userId: session.user.id },
+    include: { messages: true },
+  })
+
+  return Response.json({
+    threadId: thread.id,
+    messages: [],
+  })
+}


### PR DESCRIPTION
## Summary
- Save chat messages to DB using existing ChatThread/ChatMessage tables
- Thread loaded server-side on page visit — messages survive page refreshes
- "New conversation" button archives current thread and starts fresh
- Assistant responses saved via `onFinish` callback with model ID
- User messages saved with upsert to handle retries gracefully

## Test plan
- [ ] Send a message, refresh the page — message persists
- [ ] Click "New conversation" — old messages archived, fresh chat
- [ ] Both user and assistant messages saved to DB
- [ ] No duplicate messages on retry

Closes NAN-406

🤖 Generated with [Claude Code](https://claude.com/claude-code)