### PR TITLE
feat: add toast notifications for statement processing

### DIFF
--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 
 import { auth } from '@/lib/auth'
 import { Navbar } from '@/components/layout/navbar'
+import { Toaster } from '@/components/ui/sonner'
 
 export default async function PrivateLayout({
   children,
@@ -23,6 +24,7 @@ export default async function PrivateLayout({
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {children}
       </main>
+      <Toaster richColors position="bottom-right" />
     </div>
   )
 }

--- a/src/app/api/process-statement/[jobId]/route.ts
+++ b/src/app/api/process-statement/[jobId]/route.ts
@@ -1,0 +1,43 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { jobId } = await params
+
+  const job = await prisma.processingJob.findUnique({
+    where: { id: jobId, userId: session.user.id },
+    include: {
+      logs: {
+        orderBy: { sequenceNumber: 'asc' },
+      },
+    },
+  })
+
+  if (!job) {
+    return Response.json({ error: 'Job not found' }, { status: 404 })
+  }
+
+  return Response.json({
+    id: job.id,
+    status: job.status,
+    fileName: job.fileName,
+    errorMessage: job.errorMessage,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    logs: job.logs.map(l => ({
+      title: l.title,
+      content: l.content,
+      logType: l.logType,
+      createdAt: l.createdAt,
+    })),
+  })
+}

--- a/src/app/api/process-statement/route.ts
+++ b/src/app/api/process-statement/route.ts
@@ -4,9 +4,22 @@ import { NextRequest, NextResponse } from 'next/server'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { processStatement } from '@/lib/services/statement-processor'
+import { prisma } from '@/lib/prisma'
 
 // pdf-parse v1 has no proper ESM/TS types — use require
 const pdfParse = require('pdf-parse')
+
+async function addLog(
+  jobId: string,
+  seq: number,
+  logType: string,
+  title: string,
+  content?: string,
+) {
+  await prisma.processingLog.create({
+    data: { jobId, sequenceNumber: seq, logType, title, content },
+  })
+}
 
 export async function POST(request: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -21,8 +34,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
+  // Create processing job
+  const job = await prisma.processingJob.create({
+    data: {
+      userId: session.user.id,
+      fileName,
+      status: 'processing',
+      startedAt: new Date(),
+    },
+  })
+
+  let logSeq = 0
+
   try {
     // Read PDF from disk
+    await addLog(job.id, ++logSeq, 'info', 'Extracting text from PDF')
     const fullPath = join(process.cwd(), 'data', 'uploads', filePath)
     const pdfBuffer = await readFile(fullPath)
 
@@ -31,13 +57,21 @@ export async function POST(request: NextRequest) {
     const pdfText: string = pdfData.text
 
     if (!pdfText || pdfText.trim().length === 0) {
+      await addLog(job.id, ++logSeq, 'error', 'PDF text extraction failed', 'Could not extract text from PDF. The file may be scanned/image-based.')
+      await prisma.processingJob.update({
+        where: { id: job.id },
+        data: { status: 'failed', errorMessage: 'Could not extract text from PDF', completedAt: new Date() },
+      })
       return NextResponse.json(
-        { error: 'Could not extract text from PDF. The file may be scanned/image-based.' },
+        { error: 'Could not extract text from PDF. The file may be scanned/image-based.', jobId: job.id },
         { status: 422 },
       )
     }
 
+    await addLog(job.id, ++logSeq, 'info', 'Text extracted successfully', `${pdfText.length} characters extracted`)
+
     // Process with AI
+    await addLog(job.id, ++logSeq, 'info', 'Processing with AI')
     const result = await processStatement(
       pdfText,
       fileName,
@@ -47,22 +81,46 @@ export async function POST(request: NextRequest) {
       statementId,
     )
 
+    await addLog(job.id, ++logSeq, 'info', 'Transactions saved', `${result.transactionCount} transactions extracted`)
+    await addLog(job.id, ++logSeq, 'info', 'Balance verification complete', result.isBalanced ? 'Statement balanced' : 'Statement unbalanced')
+
+    // Update job as completed
+    await prisma.processingJob.update({
+      where: { id: job.id },
+      data: {
+        status: 'completed',
+        statementId: result.statement?.id,
+        completedAt: new Date(),
+      },
+    })
+
+    await addLog(job.id, ++logSeq, 'success', 'Processing complete')
+
     return NextResponse.json({
       success: true,
       data: result,
       message: result.message,
+      jobId: job.id,
     })
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to process statement'
+
+    await addLog(job.id, ++logSeq, 'error', 'Processing failed', errorMessage)
+    await prisma.processingJob.update({
+      where: { id: job.id },
+      data: { status: 'failed', errorMessage, completedAt: new Date() },
+    })
+
     if (error instanceof Error && error.message.includes('Duplicate statement detected')) {
       return NextResponse.json(
-        { success: false, isDuplicate: true, message: error.message },
+        { success: false, isDuplicate: true, message: error.message, jobId: job.id },
         { status: 409 },
       )
     }
 
     console.error('Process statement error:', error)
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to process statement' },
+      { error: errorMessage, jobId: job.id },
       { status: 500 },
     )
   }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
+
+function Toaster({ ...props }: ToasterProps) {
+  return (
+    <Sonner
+      className="toaster group"
+      style={
+        {
+          '--normal-bg': 'white',
+          '--normal-text': '#1f2937',
+          '--normal-border': '#e5e7eb',
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## Summary
- Replace inline status text with sonner toast notifications for statement upload/processing
- Toast shows: uploading → processing with AI → success (with transaction count + balance status) or error
- Add ProcessingJob/ProcessingLog tracking in the process-statement API for audit trail
- New GET endpoint `/api/process-statement/[jobId]` for job status polling

## Test plan
- [ ] Upload a statement → see toast progress through each phase
- [ ] Successful processing shows transaction count and balance status in toast
- [ ] Duplicate upload shows warning toast
- [ ] Failed processing shows error toast with message
- [ ] ProcessingJob and ProcessingLog entries created in DB

Closes NAN-407

🤖 Generated with [Claude Code](https://claude.com/claude-code)