### PR TITLE
feat: add PDF viewer and balance equation to statement detail

### DIFF
--- a/src/app/(private)/statements/[id]/page.tsx
+++ b/src/app/(private)/statements/[id]/page.tsx
@@ -40,6 +40,7 @@ export default async function StatementDetailPage({ params }: Props) {
     verificationStatus: statement.verificationStatus,
     discrepancyAmount: statement.discrepancyAmount,
     isProcessed: statement.isProcessed,
+    fileUrl: statement.fileUrl,
     transactions: statement.transactions.map(tx => ({
       id: tx.id,
       date: tx.transactionDate.toISOString(),

--- a/src/app/api/statements/[id]/pdf/route.ts
+++ b/src/app/api/statements/[id]/pdf/route.ts
@@ -1,0 +1,40 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const { id } = await params
+
+  const statement = await prisma.bankStatement.findFirst({
+    where: { id, userId: session.user.id },
+    select: { fileUrl: true, fileName: true },
+  })
+
+  if (!statement) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  try {
+    const filePath = join(process.cwd(), statement.fileUrl)
+    const fileBuffer = await readFile(filePath)
+
+    return new Response(fileBuffer, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `inline; filename="${statement.fileName}"`,
+      },
+    })
+  } catch {
+    return new Response('File not found', { status: 404 })
+  }
+}


### PR DESCRIPTION
## Summary
- Adds side-by-side layout with embedded PDF viewer and transaction table on statement detail page
- Shows opening + deposits - withdrawals = closing balance equation for at-a-glance verification
- Secure PDF serving endpoint that validates ownership

## Test plan
- [ ] Navigate to a statement detail page and verify PDF renders
- [ ] Verify balance equation shows correct values
- [ ] Test that PDF endpoint rejects unauthorized access

🤖 Generated with [Claude Code](https://claude.com/claude-code)