### PR TITLE
feat: improve chat UX with sticky input, file attachments, and tool display

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -2,10 +2,50 @@
 
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport, UIMessage } from 'ai'
-import { useState, useRef, useEffect, useMemo } from 'react'
-import { Send, Bot, Loader2, Sparkles, Plus } from 'lucide-react'
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import {
+  Send,
+  Bot,
+  Loader2,
+  Sparkles,
+  Plus,
+  Paperclip,
+  X,
+  FileText,
+  Search,
+  DollarSign,
+  PieChart,
+  Settings,
+  Calculator,
+  TrendingUp,
+  Upload,
+  Wrench,
+  CheckCircle2,
+} from 'lucide-react'
 import { useSession } from '@/lib/auth-client'
 import { UserAvatar } from '@/components/user-avatar'
+
+const TOOL_DISPLAY_INFO: Record<string, { label: string; icon: typeof Wrench }> = {
+  search_transactions: { label: 'Search Transactions', icon: Search },
+  get_account_summary: { label: 'Account Summary', icon: DollarSign },
+  get_cashflow: { label: 'Cashflow', icon: TrendingUp },
+  get_category_breakdown: { label: 'Category Breakdown', icon: PieChart },
+  get_settings: { label: 'Settings', icon: Settings },
+  update_settings: { label: 'Update Settings', icon: Settings },
+  calculate_tax: { label: 'Calculate Tax', icon: Calculator },
+  calculate_compound_growth: { label: 'Compound Growth', icon: TrendingUp },
+  calculate_rrsp: { label: 'RRSP Calculator', icon: Calculator },
+  calculate_tfsa: { label: 'TFSA Info', icon: Calculator },
+  evaluate_expression: { label: 'Calculate', icon: Calculator },
+}
+
+function getToolDisplay(toolName: string | undefined) {
+  if (!toolName) return { label: 'Processing', icon: Wrench }
+  return TOOL_DISPLAY_INFO[toolName] ?? {
+    label: toolName.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+    icon: Wrench,
+  }
+}
 
 function MarkdownContent({ text }: { text: string }) {
   const lines = text.split('\n')
@@ -82,6 +122,23 @@ function MarkdownContent({ text }: { text: string }) {
   return <>{elements}</>
 }
 
+function ToolCallDisplay({ toolName, state }: { toolName?: string; state: string }) {
+  const { label, icon: Icon } = getToolDisplay(toolName)
+  const isDone = state === 'output-available'
+
+  return (
+    <div className="my-1 flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-500">
+      <Icon className="h-3.5 w-3.5 shrink-0 text-violet-500" />
+      <span className="font-medium text-gray-700">{label}</span>
+      {isDone ? (
+        <CheckCircle2 className="ml-auto h-3.5 w-3.5 text-green-500" />
+      ) : (
+        <Loader2 className="ml-auto h-3.5 w-3.5 animate-spin text-gray-400" />
+      )}
+    </div>
+  )
+}
+
 const SUGGESTIONS = [
   'What are my top expense categories?',
   'How much did I spend last month?',
@@ -106,7 +163,12 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
   const { data: session } = useSession()
   const [threadId, setThreadId] = useState(initialThreadId)
   const [input, setInput] = useState('')
+  const [attachedFile, setAttachedFile] = useState<File | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
   const threadIdRef = useRef(threadId)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const dragCounterRef = useRef(0)
 
   useEffect(() => {
     threadIdRef.current = threadId
@@ -131,15 +193,64 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
 
   const isLoading = status === 'streaming' || status === 'submitted'
 
+  // Auto-focus on mount
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Auto-focus after loading completes (message sent and response received)
+  useEffect(() => {
+    if (!isLoading && messages.length > 0) {
+      inputRef.current?.focus()
+    }
+  }, [isLoading, messages.length])
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  function handleSubmit(e: React.FormEvent) {
+  async function uploadFile(file: File): Promise<{ filePath: string; fileName: string } | null> {
+    const formData = new FormData()
+    formData.append('file', file)
+    try {
+      const res = await fetch('/api/upload', { method: 'POST', body: formData })
+      if (!res.ok) {
+        const err = await res.json()
+        console.error('Upload failed:', err.error)
+        return null
+      }
+      return await res.json()
+    } catch (err) {
+      console.error('Upload error:', err)
+      return null
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!input.trim() || isLoading) return
-    sendMessage({ text: input })
+    if ((!input.trim() && !attachedFile) || isLoading || isUploading) return
+
+    let messageText = input.trim()
+
+    if (attachedFile) {
+      setIsUploading(true)
+      const result = await uploadFile(attachedFile)
+      setIsUploading(false)
+
+      if (result) {
+        const fileRef = `[Attached file: ${result.fileName} (${result.filePath})]`
+        messageText = messageText ? `${messageText}\n\n${fileRef}` : fileRef
+      } else {
+        // Upload failed — don't send the message
+        return
+      }
+    }
+
+    if (!messageText) return
+
+    sendMessage({ text: messageText })
     setInput('')
+    setAttachedFile(null)
   }
 
   function handleSuggestion(text: string) {
@@ -151,10 +262,80 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
     const data = await res.json()
     setThreadId(data.threadId)
     setMessages([])
+    setAttachedFile(null)
   }
 
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file) {
+      setAttachedFile(file)
+    }
+    // Reset input so the same file can be re-selected
+    e.target.value = ''
+  }
+
+  function handleRemoveFile() {
+    setAttachedFile(null)
+  }
+
+  function handleAttachClick() {
+    fileInputRef.current?.click()
+  }
+
+  // Drag & drop handlers
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current++
+    if (e.dataTransfer.types.includes('Files')) {
+      setIsDragging(true)
+    }
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current--
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false)
+    }
+  }, [])
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current = 0
+    setIsDragging(false)
+
+    const file = e.dataTransfer.files?.[0]
+    if (file) {
+      setAttachedFile(file)
+    }
+  }, [])
+
   return (
-    <div className="flex h-[calc(100vh-8rem)] flex-col">
+    <div
+      className="relative flex h-[calc(100vh-8rem)] flex-col"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {/* Drag & drop overlay */}
+      {isDragging && (
+        <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-lg border-2 border-dashed border-violet-400 bg-violet-50/80">
+          <div className="flex flex-col items-center gap-2">
+            <Upload className="h-10 w-10 text-violet-500" />
+            <p className="text-sm font-medium text-violet-700">Drop file to attach</p>
+          </div>
+        </div>
+      )}
+
       {/* Header with new conversation button */}
       {messages.length > 0 && (
         <div className="flex items-center justify-end border-b border-gray-200 px-4 py-2">
@@ -170,7 +351,7 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
       )}
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center">
             <div className="rounded-full bg-violet-100 p-4">
@@ -229,12 +410,11 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
                     if (part.type?.startsWith('tool-')) {
                       const toolPart = part as { type: string; toolCallId: string; toolName?: string; state: string }
                       return (
-                        <div key={i} className="my-1 rounded border border-gray-200 bg-white px-3 py-2 text-xs text-gray-500">
-                          <span className="font-medium">Tool:</span> {toolPart.toolName || toolPart.toolCallId}
-                          {toolPart.state === 'output-available' && (
-                            <span className="ml-2 text-green-600">Done</span>
-                          )}
-                        </div>
+                        <ToolCallDisplay
+                          key={i}
+                          toolName={toolPart.toolName}
+                          state={toolPart.state}
+                        />
                       )
                     }
                     return null
@@ -263,9 +443,42 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
         )}
       </div>
 
-      {/* Input */}
-      <div className="border-t border-gray-200 bg-white p-4">
+      {/* Sticky bottom input bar */}
+      <div className="sticky bottom-0 border-t border-gray-200 bg-white p-4">
+        {/* Attached file chip */}
+        {attachedFile && (
+          <div className="mb-2 flex items-center gap-2">
+            <div className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1.5 text-xs text-gray-700">
+              <FileText className="h-3.5 w-3.5 text-gray-500" />
+              <span className="max-w-48 truncate">{attachedFile.name}</span>
+              <button
+                type="button"
+                onClick={handleRemoveFile}
+                className="ml-0.5 rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} className="flex gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf"
+            onChange={handleFileSelect}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={handleAttachClick}
+            disabled={isLoading}
+            className="inline-flex items-center justify-center rounded-lg border border-gray-200 px-3 py-2.5 text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700 disabled:opacity-50"
+            title="Attach file"
+          >
+            <Paperclip className="h-4 w-4" />
+          </button>
           <input
             ref={inputRef}
             value={input}
@@ -276,10 +489,10 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
           />
           <button
             type="submit"
-            disabled={isLoading || !input.trim()}
+            disabled={isLoading || isUploading || (!input.trim() && !attachedFile)}
             className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
           >
-            {isLoading ? (
+            {isLoading || isUploading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               <Send className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Add sticky bottom input bar that stays anchored during scroll with auto-focus on mount and after responses
- Add file attachment support: paperclip button, file chip preview with remove, and drag & drop overlay
- Add rich tool call display with named icons (Search, Calculator, etc.) and completion states (spinner → checkmark)

## Test plan
- [ ] Verify input bar stays at bottom when scrolling through long conversations
- [ ] Verify input auto-focuses on page load and after AI response completes
- [ ] Test file attachment via paperclip button (PDF files)
- [ ] Test drag & drop file attachment with visual overlay
- [ ] Verify attached file chip shows name and can be removed
- [ ] Verify tool calls show appropriate icons and completion states

🤖 Generated with [Claude Code](https://claude.com/claude-code)