### PR TITLE
feat: add bulk statement upload with directory and zip support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^4.1.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.400.0",
     "mathjs": "^15.1.1",
     "next": "^16.2.0-canary.56",

--- a/src/app/api/upload/bulk/route.ts
+++ b/src/app/api/upload/bulk/route.ts
@@ -1,0 +1,142 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+import JSZip from 'jszip'
+
+interface UploadedFile {
+  filePath: string
+  fileName: string
+  size: number
+}
+
+async function savePdf(
+  buffer: Buffer,
+  fileName: string,
+  userId: string,
+): Promise<UploadedFile> {
+  const timestamp = Date.now()
+  const sanitizedFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_')
+  const relPath = `statements/${userId}/${timestamp}_${sanitizedFileName}`
+
+  const uploadDir = join(process.cwd(), 'data', 'uploads', 'statements', userId)
+  await mkdir(uploadDir, { recursive: true })
+
+  const fullPath = join(process.cwd(), 'data', 'uploads', relPath)
+  await writeFile(fullPath, buffer)
+
+  return {
+    filePath: relPath,
+    fileName: sanitizedFileName,
+    size: buffer.length,
+  }
+}
+
+async function extractPdfsFromZip(zipBuffer: Buffer): Promise<{ name: string, buffer: Buffer }[]> {
+  const zip = await JSZip.loadAsync(zipBuffer)
+  const pdfs: { name: string, buffer: Buffer }[] = []
+
+  for (const [path, entry] of Object.entries(zip.files)) {
+    if (entry.dir) continue
+
+    // Extract only PDF files, skip macOS resource forks and hidden files
+    const fileName = path.split('/').pop() || ''
+    if (
+      !fileName.toLowerCase().endsWith('.pdf') ||
+      fileName.startsWith('.') ||
+      path.includes('__MACOSX')
+    ) {
+      continue
+    }
+
+    const content = await entry.async('nodebuffer')
+    pdfs.push({ name: fileName, buffer: content })
+  }
+
+  return pdfs
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const formData = await request.formData()
+  const files = formData.getAll('files') as File[]
+
+  if (!files || files.length === 0) {
+    return NextResponse.json({ error: 'No files provided' }, { status: 400 })
+  }
+
+  const maxSize = 10 * 1024 * 1024 // 10MB per file
+  const maxTotalSize = 100 * 1024 * 1024 // 100MB total
+  const uploaded: UploadedFile[] = []
+  const errors: { fileName: string, error: string }[] = []
+
+  let totalSize = 0
+  for (const file of files) {
+    totalSize += file.size
+  }
+
+  if (totalSize > maxTotalSize) {
+    return NextResponse.json(
+      { error: 'Total upload size exceeds 100MB limit' },
+      { status: 400 },
+    )
+  }
+
+  for (const file of files) {
+    try {
+      if (file.name.toLowerCase().endsWith('.zip')) {
+        // Handle zip file — extract PDFs
+        if (file.size > maxTotalSize) {
+          errors.push({ fileName: file.name, error: 'Zip file exceeds 100MB limit' })
+          continue
+        }
+
+        const zipBuffer = Buffer.from(await file.arrayBuffer())
+        const pdfs = await extractPdfsFromZip(zipBuffer)
+
+        if (pdfs.length === 0) {
+          errors.push({ fileName: file.name, error: 'No PDF files found in zip' })
+          continue
+        }
+
+        for (const pdf of pdfs) {
+          if (pdf.buffer.length > maxSize) {
+            errors.push({ fileName: pdf.name, error: 'File exceeds 10MB limit' })
+            continue
+          }
+
+          const result = await savePdf(pdf.buffer, pdf.name, session.user.id)
+          uploaded.push(result)
+        }
+      } else if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
+        // Handle individual PDF
+        if (file.size > maxSize) {
+          errors.push({ fileName: file.name, error: 'File exceeds 10MB limit' })
+          continue
+        }
+
+        const buffer = Buffer.from(await file.arrayBuffer())
+        const result = await savePdf(buffer, file.name, session.user.id)
+        uploaded.push(result)
+      } else {
+        errors.push({ fileName: file.name, error: 'Unsupported file type — only PDF and ZIP files are accepted' })
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      errors.push({ fileName: file.name, error: message })
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    uploaded,
+    errors,
+    totalUploaded: uploaded.length,
+    totalErrors: errors.length,
+  })
+}

--- a/src/components/statements/upload-button.tsx
+++ b/src/components/statements/upload-button.tsx
@@ -1,27 +1,99 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { Loader2, Upload } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { ChevronDown, FolderOpen, Loader2, Upload } from 'lucide-react'
+import { useRef, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 
+interface UploadedFile {
+  filePath: string
+  fileName: string
+  size: number
+}
+
+interface ProcessResult {
+  fileName: string
+  success: boolean
+  transactionCount?: number
+  isBalanced?: boolean
+  isDuplicate?: boolean
+  error?: string
+}
+
 export function UploadButton() {
   const [uploading, setUploading] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const folderInputRef = useRef<HTMLInputElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
 
-  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (!file) return
+  const closeMenu = useCallback(() => setMenuOpen(false), [])
 
+  async function processFile(
+    file: UploadedFile,
+    index: number,
+    total: number,
+    batchToastId: string | number,
+  ): Promise<ProcessResult> {
+    toast.loading(`Processing ${index + 1} of ${total} statements...`, {
+      id: batchToastId,
+      description: file.fileName,
+    })
+
+    const processRes = await fetch('/api/process-statement', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filePath: file.filePath,
+        fileName: file.fileName,
+        fileSize: file.size,
+      }),
+    })
+
+    const result = await processRes.json()
+
+    if (processRes.status === 409 && result.isDuplicate) {
+      return { fileName: file.fileName, success: false, isDuplicate: true }
+    }
+
+    if (!processRes.ok) {
+      return {
+        fileName: file.fileName,
+        success: false,
+        error: result.error || 'Processing failed',
+      }
+    }
+
+    return {
+      fileName: file.fileName,
+      success: true,
+      transactionCount: result.data?.transactionCount ?? 0,
+      isBalanced: result.data?.isBalanced,
+    }
+  }
+
+  async function handleFiles(files: FileList | File[]) {
+    const fileArray = Array.from(files)
+    if (fileArray.length === 0) return
+
+    // For a single PDF (not zip), use the original simple flow
+    if (fileArray.length === 1 && !fileArray[0].name.toLowerCase().endsWith('.zip')) {
+      await handleSingleFile(fileArray[0])
+      return
+    }
+
+    await handleBulkUpload(fileArray)
+  }
+
+  async function handleSingleFile(file: File) {
     setUploading(true)
     const toastId = toast.loading('Uploading PDF...', {
       description: file.name,
     })
 
     try {
-      // Upload PDF
       const formData = new FormData()
       formData.append('file', file)
 
@@ -37,7 +109,6 @@ export function UploadButton() {
 
       const { filePath, fileName, size } = await uploadRes.json()
 
-      // Process statement with AI
       toast.loading('Processing with AI...', {
         id: toastId,
         description: `${fileName} — Extracting text and analyzing transactions`,
@@ -80,40 +151,214 @@ export function UploadButton() {
       })
     } finally {
       setUploading(false)
-      if (fileInputRef.current) {
-        fileInputRef.current.value = ''
-      }
+      resetInputs()
     }
   }
 
+  async function handleBulkUpload(files: File[]) {
+    setUploading(true)
+    const batchToastId = toast.loading(`Uploading ${files.length} file${files.length > 1 ? 's' : ''}...`, {
+      description: 'Preparing upload...',
+    })
+
+    try {
+      // Upload all files via bulk endpoint
+      const formData = new FormData()
+      for (const file of files) {
+        formData.append('files', file)
+      }
+
+      const uploadRes = await fetch('/api/upload/bulk', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!uploadRes.ok) {
+        const err = await uploadRes.json()
+        throw new Error(err.error || 'Upload failed')
+      }
+
+      const { uploaded, errors: uploadErrors } = await uploadRes.json() as {
+        uploaded: UploadedFile[]
+        errors: { fileName: string, error: string }[]
+      }
+
+      // Show upload errors
+      for (const err of uploadErrors) {
+        toast.error(`Upload failed: ${err.fileName}`, {
+          description: err.error,
+        })
+      }
+
+      if (uploaded.length === 0) {
+        toast.error('No files uploaded', {
+          id: batchToastId,
+          description: 'No valid PDF files were found',
+        })
+        return
+      }
+
+      // Process each uploaded file sequentially
+      const results: ProcessResult[] = []
+
+      for (let i = 0; i < uploaded.length; i++) {
+        const result = await processFile(uploaded[i], i, uploaded.length, batchToastId)
+        results.push(result)
+      }
+
+      // Summarize results
+      const succeeded = results.filter(r => r.success)
+      const duplicates = results.filter(r => r.isDuplicate)
+      const failed = results.filter(r => !r.success && !r.isDuplicate)
+      const totalTransactions = succeeded.reduce((sum, r) => sum + (r.transactionCount ?? 0), 0)
+
+      const parts: string[] = []
+      if (succeeded.length > 0) {
+        parts.push(`${succeeded.length} processed (${totalTransactions} transactions)`)
+      }
+      if (duplicates.length > 0) {
+        parts.push(`${duplicates.length} duplicate${duplicates.length > 1 ? 's' : ''}`)
+      }
+      if (failed.length > 0) {
+        parts.push(`${failed.length} failed`)
+      }
+
+      if (failed.length > 0 && succeeded.length === 0) {
+        toast.error('Batch processing failed', {
+          id: batchToastId,
+          description: parts.join(' · '),
+        })
+      } else if (failed.length > 0 || duplicates.length > 0) {
+        toast.warning('Batch complete with issues', {
+          id: batchToastId,
+          description: parts.join(' · '),
+        })
+      } else {
+        toast.success('All statements processed!', {
+          id: batchToastId,
+          description: parts.join(' · '),
+        })
+      }
+
+      router.refresh()
+    } catch (error) {
+      console.error('Bulk upload error:', error)
+      toast.error('Bulk upload failed', {
+        id: batchToastId,
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    } finally {
+      setUploading(false)
+      resetInputs()
+    }
+  }
+
+  function resetInputs() {
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    if (folderInputRef.current) folderInputRef.current.value = ''
+  }
+
+  function handleFileInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files
+    if (files && files.length > 0) handleFiles(files)
+  }
+
+  function handleFolderInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files
+    if (!files || files.length === 0) return
+
+    // Filter to only PDF files from the directory
+    const pdfFiles = Array.from(files).filter(
+      f => f.name.toLowerCase().endsWith('.pdf'),
+    )
+
+    if (pdfFiles.length === 0) {
+      toast.error('No PDF files found', {
+        description: 'The selected folder does not contain any PDF files',
+      })
+      return
+    }
+
+    handleFiles(pdfFiles)
+  }
+
   return (
-    <>
+    <div className="relative">
+      {/* Hidden file inputs */}
       <input
         ref={fileInputRef}
         type="file"
-        accept=".pdf"
-        onChange={handleFileSelect}
+        accept=".pdf,.zip"
+        multiple
+        onChange={handleFileInputChange}
+        className="hidden"
+        disabled={uploading}
+      />
+      <input
+        ref={folderInputRef}
+        type="file"
+        // @ts-expect-error — webkitdirectory is not in React's type defs
+        webkitdirectory=""
+        onChange={handleFolderInputChange}
         className="hidden"
         disabled={uploading}
       />
 
-      <Button
-        onClick={() => fileInputRef.current?.click()}
-        disabled={uploading}
-        variant="outline"
-      >
-        {uploading ? (
-          <>
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Processing...
-          </>
-        ) : (
-          <>
-            <Upload className="h-4 w-4" />
-            Upload Statement
-          </>
-        )}
-      </Button>
-    </>
+      <div className="flex">
+        <Button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          variant="outline"
+          className="rounded-r-none"
+        >
+          {uploading ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Processing...
+            </>
+          ) : (
+            <>
+              <Upload className="h-4 w-4" />
+              Upload Statements
+            </>
+          )}
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          className="-ml-px rounded-l-none border-l-0"
+          disabled={uploading}
+          onClick={() => setMenuOpen(prev => !prev)}
+          aria-label="More upload options"
+        >
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {menuOpen && (
+        <>
+          {/* Backdrop to close menu */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={closeMenu}
+          />
+          <div
+            ref={menuRef}
+            className="absolute right-0 z-50 mt-1 w-56 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+          >
+            <button
+              className="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+              onClick={() => {
+                closeMenu()
+                folderInputRef.current?.click()
+              }}
+            >
+              <FolderOpen className="h-4 w-4" />
+              Upload Folder
+            </button>
+          </div>
+        </>
+      )}
+    </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,6 +3195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -4631,6 +4638,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
+  languageName: node
+  linkType: hard
+
 "immer@npm:^10.1.1":
   version: 10.2.0
   resolution: "immer@npm:10.2.0"
@@ -4662,7 +4676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:^2.0.3, inherits@npm:^2.0.4":
+"inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -4957,6 +4971,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 18b5be6669be53425f0b84098732670ed4e727e3af33bc7f948aac01782110eb9a18b3b329c5323bcdd3acdaae547ee077d3951317e7f133bff7105264b3003d
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^2.0.0":
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
@@ -5095,6 +5116,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jszip@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
+  dependencies:
+    lie: "npm:~3.3.0"
+    pako: "npm:~1.0.2"
+    readable-stream: "npm:~2.3.6"
+    setimmediate: "npm:^1.0.5"
+  checksum: 58e01ec9c4960383fb8b38dd5f67b83ccc1ec215bf74c8a5b32f42b6e5fb79fada5176842a11409c4051b5b94275044851814a31076bf49e1be218d3ef57c863
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -5134,6 +5167,15 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"lie@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "lie@npm:3.3.0"
+  dependencies:
+    immediate: "npm:~3.0.5"
+  checksum: 56dd113091978f82f9dc5081769c6f3b947852ecf9feccaf83e14a123bc630c2301439ce6182521e5fbafbde88e88ac38314327a4e0493a1bea7e0699a7af808
   languageName: node
   linkType: hard
 
@@ -5899,6 +5941,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     eslint: "npm:^9.0.0"
     eslint-config-next: "npm:^16.2.0-canary.56"
+    jszip: "npm:^3.10.1"
     lucide-react: "npm:^0.400.0"
     mathjs: "npm:^15.1.1"
     next: "npm:^16.2.0-canary.56"
@@ -5964,6 +6007,13 @@ __metadata:
   version: 7.0.4
   resolution: "p-map@npm:7.0.4"
   checksum: a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
+  languageName: node
+  linkType: hard
+
+"pako@npm:~1.0.2":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
   languageName: node
   linkType: hard
 
@@ -6183,6 +6233,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -6373,6 +6430,21 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
   languageName: node
   linkType: hard
 
@@ -6595,6 +6667,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
 "safe-push-apply@npm:^1.0.0":
   version: 1.0.0
   resolution: "safe-push-apply@npm:1.0.0"
@@ -6703,6 +6782,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.0.0"
   checksum: ca5c3ccbba479d07c30460e367e66337cec825560b11e8ba9c5ebe13a2a0d6021ae34eddf94ff3dfe17a3104dc1f191519cb6c48378b503e5c3f36393938776a
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 5bae81bfdbfbd0ce992893286d49c9693c82b1bcc00dcaaf3a09c8f428fdeacf4190c013598b81875dfac2b08a572422db7df779a99332d0fce186d15a3e4d49
   languageName: node
   linkType: hard
 
@@ -7057,6 +7143,15 @@ __metadata:
   dependencies:
     safe-buffer: "npm:~5.2.0"
   checksum: 810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: "npm:~5.1.0"
+  checksum: b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
   languageName: node
   linkType: hard
 
@@ -7539,7 +7634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1":
+"util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942


### PR DESCRIPTION
## Summary
- Add split upload button with dropdown for folder upload option
- Support multi-file PDF selection and zip file extraction (filters __MACOSX, hidden files)
- Sequential batch processing with progress toasts and final summary (succeeded/duplicates/failed)
- New `/api/upload/bulk` endpoint for multi-file uploads with size limits (10MB/file, 100MB total)

## Test plan
- [ ] Verify single PDF upload still works as before
- [ ] Test multi-select PDF upload
- [ ] Test folder upload (webkitdirectory) — filters to PDFs only
- [ ] Test zip file upload with mixed content — extracts only PDFs
- [ ] Verify progress toasts show sequential processing
- [ ] Verify summary toast shows correct counts
- [ ] Test size limit enforcement (>10MB single file, >100MB total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)