### PR TITLE
feat: accept more file types in chat uploads

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -466,7 +466,7 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
           <input
             ref={fileInputRef}
             type="file"
-            accept=".pdf"
+            accept=".pdf,.md,.csv,.txt,.jpg,.jpeg,.png,.xlsx,.xls"
             onChange={handleFileSelect}
             className="hidden"
           />


### PR DESCRIPTION
## Summary
- Expand chat file picker to accept PDF, Markdown, CSV, Text, Images (JPG/PNG), and Excel (XLSX/XLS)
- Update upload API with dual-layer validation (MIME type + file extension fallback) to handle OS-specific MIME type quirks
- Rename upload directory from `statements/` to `attachments/` to reflect general-purpose usage

## Test plan
- [ ] Open chat, click paperclip — verify .md, .csv, .txt, .jpg, .xlsx files are selectable
- [ ] Upload a markdown file and verify it uploads successfully
- [ ] Upload a CSV file and verify it uploads
- [ ] Drag and drop an image file into chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)