### PR TITLE
feat: add conversation history sidebar

### DIFF
--- a/src/app/api/chat/threads/[threadId]/messages/route.ts
+++ b/src/app/api/chat/threads/[threadId]/messages/route.ts
@@ -1,0 +1,38 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+import { NextRequest } from 'next/server'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ threadId: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+  }
+
+  const { threadId } = await params
+
+  const thread = await prisma.chatThread.findFirst({
+    where: { id: threadId, userId: session.user.id },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!thread) {
+    return new Response(JSON.stringify({ error: 'Thread not found' }), { status: 404 })
+  }
+
+  const messages = thread.messages.map(m => ({
+    id: m.id,
+    role: m.role,
+    content: m.content,
+    createdAt: m.createdAt.toISOString(),
+  }))
+
+  return Response.json({ threadId: thread.id, messages })
+}

--- a/src/components/chat/thread-sidebar.tsx
+++ b/src/components/chat/thread-sidebar.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Plus, Search, MessageSquare, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+
+interface ThreadItem {
+  id: string
+  title: string
+  updatedAt: string
+  isArchived: boolean
+  messageCount: number
+}
+
+interface ThreadSidebarProps {
+  currentThreadId: string
+  isOpen: boolean
+  onClose: () => void
+  onSelectThread: (threadId: string) => void
+  onNewThread: () => void
+}
+
+function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffSeconds < 60) return 'Just now'
+  if (diffMinutes < 60) return `${diffMinutes}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7) return `${diffDays}d ago`
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
+
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function ThreadList({
+  threads,
+  currentThreadId,
+  onSelectThread,
+}: {
+  threads: ThreadItem[]
+  currentThreadId: string
+  onSelectThread: (threadId: string) => void
+}) {
+  if (threads.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center px-4 py-12 text-center">
+        <MessageSquare className="h-8 w-8 text-gray-300" />
+        <p className="mt-2 text-sm text-gray-500">No conversations yet</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {threads.map(thread => (
+        <button
+          key={thread.id}
+          type="button"
+          onClick={() => onSelectThread(thread.id)}
+          className={cn(
+            'flex w-full flex-col gap-0.5 rounded-md px-3 py-2.5 text-left transition-colors',
+            thread.id === currentThreadId
+              ? 'bg-violet-50 text-violet-900'
+              : 'text-gray-700 hover:bg-gray-50',
+          )}
+        >
+          <span className="line-clamp-1 text-sm font-medium">
+            {thread.title}
+          </span>
+          <span className="text-xs text-gray-400">
+            {formatRelativeDate(thread.updatedAt)}
+            {thread.messageCount > 0 && (
+              <> &middot; {thread.messageCount} message{thread.messageCount !== 1 ? 's' : ''}</>
+            )}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function ThreadSidebar({
+  currentThreadId,
+  isOpen,
+  onClose,
+  onSelectThread,
+  onNewThread,
+}: ThreadSidebarProps) {
+  const [threads, setThreads] = useState<ThreadItem[]>([])
+  const [search, setSearch] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  const fetchThreads = useCallback(async (query = '') => {
+    setIsLoading(true)
+    try {
+      const params = query ? `?search=${encodeURIComponent(query)}` : ''
+      const res = await fetch(`/api/chat/threads${params}`)
+      if (res.ok) {
+        const data = await res.json()
+        setThreads(data.threads)
+      }
+    } catch (error) {
+      console.error('Failed to fetch threads:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchThreads()
+    }
+  }, [isOpen, fetchThreads])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const timer = setTimeout(() => {
+      fetchThreads(search)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [search, isOpen, fetchThreads])
+
+  function handleSelectThread(threadId: string) {
+    onSelectThread(threadId)
+    onClose()
+  }
+
+  function handleNewThread() {
+    onNewThread()
+    onClose()
+  }
+
+  const sidebarContent = (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+        <h2 className="text-sm font-semibold text-gray-900">Conversations</h2>
+        <button
+          type="button"
+          onClick={handleNewThread}
+          className="inline-flex items-center gap-1.5 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New
+        </button>
+      </div>
+
+      <div className="border-b border-gray-200 px-4 py-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search conversations..."
+            className="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-8 pr-8 text-xs outline-none placeholder:text-gray-400 focus:border-violet-300 focus:bg-white focus:ring-1 focus:ring-violet-300"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-gray-400 hover:text-gray-600"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        {isLoading && threads.length === 0 ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-violet-600" />
+          </div>
+        ) : (
+          <ThreadList
+            threads={threads}
+            currentThreadId={currentThreadId}
+            onSelectThread={handleSelectThread}
+          />
+        )}
+      </div>
+    </div>
+  )
+
+  // Desktop: persistent sidebar
+  // Mobile: sheet overlay
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <div
+        className={cn(
+          'hidden md:block shrink-0 border-r border-gray-200 bg-white transition-all duration-200',
+          isOpen ? 'w-72' : 'w-0 overflow-hidden',
+        )}
+      >
+        {sidebarContent}
+      </div>
+
+      {/* Mobile sheet */}
+      <Sheet open={isOpen} onOpenChange={open => { if (!open) onClose() }}>
+        <SheetContent side="left" className="w-80 p-0">
+          <SheetHeader className="sr-only">
+            <SheetTitle>Conversations</SheetTitle>
+          </SheetHeader>
+          {sidebarContent}
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const Sheet = DialogPrimitive.Root
+
+const SheetTrigger = DialogPrimitive.Trigger
+
+const SheetClose = DialogPrimitive.Close
+
+const SheetPortal = DialogPrimitive.Portal
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-white p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+)
+
+interface SheetContentProps
+  extends React.ComponentProps<typeof DialogPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+function SheetContent({
+  side = 'right',
+  className,
+  children,
+  ...props
+}: SheetContentProps) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-gray-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-gray-100">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+        {children}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col space-y-2 text-center sm:text-left',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-lg font-semibold text-gray-950', className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn('text-sm text-gray-500', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
## Summary
- Adds a collapsible sidebar to browse and switch between past conversations
- Thread list shows title (auto-generated from first message), relative date, and message count
- Search with 300ms debounce filters threads by title and message content
- Desktop: persistent sidebar (w-72) on left, mobile: Sheet overlay from left
- New API: `GET /api/chat/threads/:id/messages` for loading thread history
- Updated `GET /api/chat/threads` to return all threads with previews and counts
- Auto-generates thread titles from first user message (~50 chars at word boundary)

Closes NAN-422

## Test plan
- [ ] Click sidebar toggle (panel icon) — verify sidebar opens with thread list
- [ ] Click a past conversation — verify it loads messages correctly
- [ ] Start a new conversation — verify it appears in sidebar after first message
- [ ] Type in search box — verify threads are filtered
- [ ] Test on mobile viewport — verify Sheet overlay works
- [ ] Verify current thread is highlighted in violet

🤖 Generated with [Claude Code](https://claude.com/claude-code)