### PR TITLE
feat: show Langfuse trace link on assistant messages

### DIFF
--- a/src/app/(private)/chat/page.tsx
+++ b/src/app/(private)/chat/page.tsx
@@ -35,6 +35,13 @@ export default async function ChatPage() {
     parts: [{ type: 'text' as const, text: m.content }],
   }))
 
+  const initialTraceIds: Record<string, string> = {}
+  for (const m of thread.messages) {
+    if (m.traceId) {
+      initialTraceIds[m.id] = m.traceId
+    }
+  }
+
   // Check if user needs onboarding (no personal context set and no previous messages)
   const settings = await prisma.userSettings.findUnique({
     where: { userId: session.user.id },
@@ -50,6 +57,7 @@ export default async function ChatPage() {
     <ChatInterface
       threadId={thread.id}
       initialMessages={initialMessages}
+      initialTraceIds={initialTraceIds}
       isNewUser={isNewUser}
     />
   )

--- a/src/app/api/chat/threads/[threadId]/messages/route.ts
+++ b/src/app/api/chat/threads/[threadId]/messages/route.ts
@@ -32,6 +32,7 @@ export async function GET(
     role: m.role,
     content: m.content,
     createdAt: m.createdAt.toISOString(),
+    traceId: m.traceId,
   }))
 
   return Response.json({ threadId: thread.id, messages })


### PR DESCRIPTION
## Summary
- Adds a small bug icon below each assistant message linking to its Langfuse trace
- TraceIds loaded from database when viewing thread history or switching conversations
- Icon opens `https://langfuse.openfinance.to/trace/<traceId>` in a new tab
- Shown for all authenticated users (can be restricted to admin later)

Closes NAN-419

## Test plan
- [ ] Send a chat message, reload the page — verify bug icon appears below assistant messages
- [ ] Click the bug icon — verify it opens the Langfuse trace in a new tab
- [ ] Switch conversations via sidebar — verify trace links load for historical messages
- [ ] New conversation — verify no stale trace links from previous thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)