### PR TITLE
fix: prevent double conversation sidebar rendering

### DIFF
--- a/src/components/chat/thread-sidebar.tsx
+++ b/src/components/chat/thread-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Plus, Search, MessageSquare, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/hooks/use-is-mobile'
 import {
   Sheet,
   SheetContent,
@@ -99,6 +100,7 @@ export function ThreadSidebar({
   onSelectThread,
   onNewThread,
 }: ThreadSidebarProps) {
+  const isMobile = useIsMobile()
   const [threads, setThreads] = useState<ThreadItem[]>([])
   const [search, setSearch] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -197,21 +199,9 @@ export function ThreadSidebar({
     </div>
   )
 
-  // Desktop: persistent sidebar
-  // Mobile: sheet overlay
-  return (
-    <>
-      {/* Desktop sidebar */}
-      <div
-        className={cn(
-          'hidden md:block shrink-0 border-r border-gray-200 bg-white transition-all duration-200',
-          isOpen ? 'w-72' : 'w-0 overflow-hidden',
-        )}
-      >
-        {sidebarContent}
-      </div>
-
-      {/* Mobile sheet */}
+  // Mobile: sheet overlay, Desktop: inline collapsible sidebar
+  if (isMobile) {
+    return (
       <Sheet open={isOpen} onOpenChange={open => { if (!open) onClose() }}>
         <SheetContent side="left" className="w-80 p-0">
           <SheetHeader className="sr-only">
@@ -220,6 +210,17 @@ export function ThreadSidebar({
           {sidebarContent}
         </SheetContent>
       </Sheet>
-    </>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'shrink-0 border-r border-gray-200 bg-white transition-all duration-200',
+        isOpen ? 'w-72' : 'w-0 overflow-hidden',
+      )}
+    >
+      {sidebarContent}
+    </div>
   )
 }

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+
+const MOBILE_BREAKPOINT = 768 // matches Tailwind's `md` breakpoint
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+
+    function handleChange(e: MediaQueryListEvent | MediaQueryList) {
+      setIsMobile(e.matches)
+    }
+
+    handleChange(mql)
+    mql.addEventListener('change', handleChange)
+    return () => mql.removeEventListener('change', handleChange)
+  }, [])
+
+  return isMobile
+}


### PR DESCRIPTION
## Summary
- Fixes bug where both desktop sidebar AND mobile Sheet overlay rendered simultaneously
- Root cause: Sheet portal bypassed parent CSS `hidden md:block` — both panels were visible on desktop
- Solution: `useIsMobile` hook for conditional rendering — only one sidebar renders at a time
- Mobile: Sheet overlay only. Desktop: inline collapsible sidebar only.

Closes NAN-429

## Test plan
- [ ] Open chat on desktop — click sidebar toggle, verify single sidebar appears
- [ ] Open chat on mobile — click toggle, verify Sheet slides in (no double panel)
- [ ] Resize browser across breakpoint — verify correct variant switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)