### PR TITLE
feat: inline transaction editing with ag-grid + fix PDF path

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-select": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "ag-grid-community": "^35.1.0",
+    "ag-grid-react": "^35.1.0",
     "ai": "^6.0.97",
     "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.0",

--- a/src/app/api/statements/[id]/pdf/route.ts
+++ b/src/app/api/statements/[id]/pdf/route.ts
@@ -25,7 +25,7 @@ export async function GET(
   }
 
   try {
-    const filePath = join(process.cwd(), statement.fileUrl)
+    const filePath = join(process.cwd(), 'data', 'uploads', statement.fileUrl)
     const fileBuffer = await readFile(filePath)
 
     return new Response(fileBuffer, {

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,0 +1,95 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+import { NextRequest, NextResponse } from 'next/server'
+
+const VALID_CATEGORIES = [
+  'expense',
+  'income',
+  'owner-pay',
+  'internal-transfer',
+  'shareholder-loan',
+]
+
+const VALID_TRANSACTION_TYPES = ['credit', 'debit']
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+
+  // Validate the user owns this transaction
+  const transaction = await prisma.transaction.findFirst({
+    where: { id, userId: session.user.id },
+  })
+
+  if (!transaction) {
+    return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+  }
+
+  // Build update data from allowed fields
+  const updateData: Record<string, unknown> = {}
+
+  if (body.description !== undefined) {
+    if (typeof body.description !== 'string' || body.description.trim().length === 0) {
+      return NextResponse.json({ error: 'Description must be a non-empty string' }, { status: 400 })
+    }
+    updateData.description = body.description.trim()
+  }
+
+  if (body.amount !== undefined) {
+    const amount = Number(body.amount)
+    if (isNaN(amount)) {
+      return NextResponse.json({ error: 'Amount must be a number' }, { status: 400 })
+    }
+    updateData.amount = amount
+  }
+
+  if (body.category !== undefined) {
+    if (body.category !== null && !VALID_CATEGORIES.includes(body.category)) {
+      return NextResponse.json(
+        { error: `Category must be one of: ${VALID_CATEGORIES.join(', ')}` },
+        { status: 400 },
+      )
+    }
+    updateData.category = body.category
+  }
+
+  if (body.transactionType !== undefined) {
+    if (!VALID_TRANSACTION_TYPES.includes(body.transactionType)) {
+      return NextResponse.json(
+        { error: `Transaction type must be one of: ${VALID_TRANSACTION_TYPES.join(', ')}` },
+        { status: 400 },
+      )
+    }
+    updateData.transactionType = body.transactionType
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 })
+  }
+
+  const updated = await prisma.transaction.update({
+    where: { id },
+    data: updateData,
+  })
+
+  return NextResponse.json({
+    success: true,
+    transaction: {
+      id: updated.id,
+      description: updated.description,
+      amount: updated.amount,
+      balance: updated.balance,
+      category: updated.category,
+      transactionType: updated.transactionType,
+    },
+  })
+}

--- a/src/components/statements/statement-detail.tsx
+++ b/src/components/statements/statement-detail.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import { formatDate } from '@/lib/utils/date'
 import { toggleHumanVerified, reprocessStatement, deleteStatement } from '@/app/(private)/statements/actions'
+import { TransactionGrid } from '@/components/transactions/transaction-grid'
 
 interface Transaction {
   id: string
@@ -352,54 +353,11 @@ export function StatementDetail({ statement: initial }: StatementDetailProps) {
           <h2 className="text-lg font-semibold text-gray-900">
             Transactions ({statement.transactions.length})
           </h2>
+          <p className="mt-1 text-xs text-gray-500">
+            Click a cell to edit. Changes save automatically.
+          </p>
           <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white">
-            <div className="max-h-[600px] overflow-y-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="sticky top-0 bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                      Date
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                      Description
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                      Category
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
-                      Amount
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {statement.transactions.map(tx => (
-                    <tr key={tx.id} className="hover:bg-gray-50">
-                      <td className="whitespace-nowrap px-4 py-2.5 text-sm text-gray-500">
-                        {formatDate(tx.date, 'MMM dd')}
-                      </td>
-                      <td className="max-w-[200px] truncate px-4 py-2.5 text-sm text-gray-900">
-                        {tx.description}
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-2.5 text-sm">
-                        {tx.category ? (
-                          <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
-                            {tx.category.replace('-', ' ')}
-                          </span>
-                        ) : (
-                          <span className="text-gray-400">&mdash;</span>
-                        )}
-                      </td>
-                      <td className={`whitespace-nowrap px-4 py-2.5 text-right text-sm font-medium ${
-                        tx.amount >= 0 ? 'text-green-600' : 'text-gray-900'
-                      }`}>
-                        {tx.amount >= 0 ? '+' : ''}
-                        ${Math.abs(tx.amount).toLocaleString('en-US', { minimumFractionDigits: 2 })}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <TransactionGrid transactions={statement.transactions} />
           </div>
         </div>
       </div>

--- a/src/components/transactions/transaction-grid.tsx
+++ b/src/components/transactions/transaction-grid.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { AgGridReact } from 'ag-grid-react'
+import {
+  AllCommunityModule,
+  type ColDef,
+  type CellValueChangedEvent,
+  type ValueFormatterParams,
+  type CellClassParams,
+  themeQuartz,
+} from 'ag-grid-community'
+
+// Register all community modules
+import { ModuleRegistry as MR } from 'ag-grid-community'
+MR.registerModules([AllCommunityModule])
+
+const CATEGORY_OPTIONS = [
+  '',
+  'expense',
+  'income',
+  'owner-pay',
+  'internal-transfer',
+  'shareholder-loan',
+]
+
+interface TransactionRow {
+  id: string
+  date: string
+  description: string
+  amount: number
+  balance: number | null
+  category: string | null
+  transactionType: string
+}
+
+interface TransactionGridProps {
+  transactions: TransactionRow[]
+  onTransactionUpdated?: (transaction: TransactionRow) => void
+}
+
+export function TransactionGrid({ transactions, onTransactionUpdated }: TransactionGridProps) {
+  const [rowData, setRowData] = useState<TransactionRow[]>(transactions)
+  const [saving, setSaving] = useState<string | null>(null)
+
+  const theme = useMemo(() => {
+    return themeQuartz.withParams({
+      fontSize: 13,
+      headerFontSize: 12,
+      rowHeight: 36,
+      headerHeight: 40,
+    })
+  }, [])
+
+  const formatCurrency = useCallback((params: ValueFormatterParams) => {
+    if (params.value == null) return ''
+    const val = Number(params.value)
+    const prefix = val >= 0 ? '+' : '-'
+    return `${prefix}$${Math.abs(val).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
+  }, [])
+
+  const formatBalance = useCallback((params: ValueFormatterParams) => {
+    if (params.value == null) return '\u2014'
+    const val = Number(params.value)
+    return `$${val.toLocaleString('en-US', { minimumFractionDigits: 2 })}`
+  }, [])
+
+  const formatDate = useCallback((params: ValueFormatterParams) => {
+    if (!params.value) return ''
+    const datePart = String(params.value).split('T')[0]
+    const parts = datePart.split('-')
+    if (parts.length !== 3) return params.value
+
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    const month = parseInt(parts[1], 10) - 1
+    const day = parseInt(parts[2], 10)
+    return `${months[month]} ${String(day).padStart(2, '0')}`
+  }, [])
+
+  const formatCategory = useCallback((params: ValueFormatterParams) => {
+    if (!params.value) return '\u2014'
+    return String(params.value).replace(/-/g, ' ')
+  }, [])
+
+  const columnDefs = useMemo<ColDef<TransactionRow>[]>(() => [
+    {
+      headerName: 'Date',
+      field: 'date',
+      sort: 'asc' as const,
+      width: 90,
+      valueFormatter: formatDate,
+      editable: false,
+    },
+    {
+      headerName: 'Description',
+      field: 'description',
+      flex: 2,
+      minWidth: 180,
+      editable: true,
+    },
+    {
+      headerName: 'Amount',
+      field: 'amount',
+      width: 120,
+      editable: true,
+      valueFormatter: formatCurrency,
+      cellClass: (params: CellClassParams<TransactionRow>) => {
+        if (params.value == null) return ''
+        return Number(params.value) >= 0 ? 'text-green-600 font-medium' : 'text-red-600 font-medium'
+      },
+    },
+    {
+      headerName: 'Balance',
+      field: 'balance',
+      width: 120,
+      editable: false,
+      valueFormatter: formatBalance,
+    },
+    {
+      headerName: 'Category',
+      field: 'category',
+      width: 140,
+      editable: true,
+      cellEditor: 'agSelectCellEditor',
+      cellEditorParams: {
+        values: CATEGORY_OPTIONS,
+      },
+      valueFormatter: formatCategory,
+    },
+    {
+      headerName: 'Type',
+      field: 'transactionType',
+      width: 90,
+      editable: false,
+      valueFormatter: (params: ValueFormatterParams) => {
+        if (!params.value) return ''
+        return String(params.value).charAt(0).toUpperCase() + String(params.value).slice(1)
+      },
+    },
+  ], [formatDate, formatCurrency, formatBalance, formatCategory])
+
+  const defaultColDef = useMemo<ColDef>(() => ({
+    sortable: true,
+    resizable: true,
+  }), [])
+
+  const onCellValueChanged = useCallback(async (event: CellValueChangedEvent<TransactionRow>) => {
+    const { data, colDef } = event
+    if (!data || !colDef.field) return
+
+    const field = colDef.field as keyof TransactionRow
+    const newValue = event.newValue
+
+    // Build update payload
+    const update: Record<string, unknown> = {}
+    if (field === 'description') {
+      update.description = newValue
+    } else if (field === 'amount') {
+      update.amount = Number(newValue)
+    } else if (field === 'category') {
+      update.category = newValue === '' ? null : newValue
+    }
+
+    if (Object.keys(update).length === 0) return
+
+    setSaving(data.id)
+    try {
+      const res = await fetch(`/api/transactions/${data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(update),
+      })
+
+      if (!res.ok) {
+        // Revert on error
+        const rowNode = event.api.getRowNode(data.id)
+        if (rowNode) {
+          rowNode.setDataValue(field, event.oldValue)
+        }
+        console.error('Failed to save transaction')
+        return
+      }
+
+      const result = await res.json()
+      if (onTransactionUpdated && result.transaction) {
+        onTransactionUpdated({
+          ...data,
+          ...result.transaction,
+          date: data.date,
+        })
+      }
+    } catch (err) {
+      // Revert on error
+      const rowNode = event.api.getRowNode(data.id)
+      if (rowNode) {
+        rowNode.setDataValue(field, event.oldValue)
+      }
+      console.error('Failed to save transaction:', err)
+    } finally {
+      setSaving(null)
+    }
+  }, [onTransactionUpdated])
+
+  const getRowId = useCallback((params: { data: TransactionRow }) => params.data.id, [])
+
+  return (
+    <div className="relative">
+      {saving && (
+        <div className="absolute right-2 top-2 z-10 rounded bg-blue-50 px-2 py-1 text-xs text-blue-600">
+          Saving...
+        </div>
+      )}
+      <div style={{ height: 600, width: '100%' }}>
+        <AgGridReact<TransactionRow>
+          theme={theme}
+          rowData={rowData}
+          columnDefs={columnDefs}
+          defaultColDef={defaultColDef}
+          getRowId={getRowId}
+          onCellValueChanged={onCellValueChanged}
+          singleClickEdit={true}
+          stopEditingWhenCellsLoseFocus={true}
+          animateRows={true}
+        />
+      </div>
+    </div>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,6 +2785,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ag-charts-types@npm:13.1.0":
+  version: 13.1.0
+  resolution: "ag-charts-types@npm:13.1.0"
+  checksum: 7f8c86b4d4f0fe6ba3ac384681fe1387e3590b94a3696e866c6fc55cb8d62a9397bd8ee1f5f6bfae40af9dbf6b0ff10c6be440fb9565a9d41a07f9339093c034
+  languageName: node
+  linkType: hard
+
+"ag-grid-community@npm:35.1.0, ag-grid-community@npm:^35.1.0":
+  version: 35.1.0
+  resolution: "ag-grid-community@npm:35.1.0"
+  dependencies:
+    ag-charts-types: "npm:13.1.0"
+  checksum: 853a2c9ed3be063b6292c72c12c247d4740b3387a0f5011554448dfacda88d07ffff0a127be0ed721fb6435e9b5a0fbcbd6e8aa4342fb8cc2a4caa12536dc0b3
+  languageName: node
+  linkType: hard
+
+"ag-grid-react@npm:^35.1.0":
+  version: 35.1.0
+  resolution: "ag-grid-react@npm:35.1.0"
+  dependencies:
+    ag-grid-community: "npm:35.1.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 21b27a68bd3d9bdfd1cc757130a25231de1ca94c564d0a36797052915a54760472b8d8a03da7799be941e9152b6823aae8e0092d6b684c8776e14aacdd791aa3
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
@@ -6158,6 +6187,8 @@ __metadata:
     "@types/node": "npm:^22.0.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
+    ag-grid-community: "npm:^35.1.0"
+    ag-grid-react: "npm:^35.1.0"
     ai: "npm:^6.0.97"
     better-auth: "npm:^1.4.18"
     class-variance-authority: "npm:^0.7.0"


### PR DESCRIPTION
## Summary
- Replace static transaction table with ag-grid for inline editing (description, amount, category)
- Add PATCH `/api/transactions/[id]` endpoint for saving edits
- Fix PDF file path resolution in statement viewer (`data/uploads/` prefix was missing)

## Test plan
- [ ] Open a statement detail page — transactions render in ag-grid
- [ ] Double-click a cell (description, amount, category) to edit inline
- [ ] Verify changes persist after page reload
- [ ] Open PDF viewer on a statement — PDF loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)