### PR TITLE
feat: document library for managing uploaded financial files

### DIFF
--- a/prisma/migrations/20260222003020_add_document_model/migration.sql
+++ b/prisma/migrations/20260222003020_add_document_model/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "fileUrl" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "documentType" TEXT NOT NULL DEFAULT 'other',
+    "tags" TEXT,
+    "description" TEXT,
+    "uploadedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Document_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Document_userId_idx" ON "Document"("userId");
+
+-- CreateIndex
+CREATE INDEX "Document_userId_documentType_idx" ON "Document"("userId", "documentType");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   chatThreads      ChatThread[]
   chatTraces       ChatTrace[]
   plaidConnections PlaidConnection[]
+  documents        Document[]
 }
 
 model Session {
@@ -316,4 +317,27 @@ model PlaidConnection {
   updatedAt       DateTime  @updatedAt
 
   @@index([userId])
+}
+
+// ============================================================
+// Document library
+// ============================================================
+
+model Document {
+  id           String   @id @default(uuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fileName     String
+  fileUrl      String   // Relative path under data/uploads/documents/
+  fileSize     Int
+  mimeType     String
+  documentType String   @default("other") // statement | tax | investment | receipt | other
+  tags         String?  // Comma-separated tags
+  description  String?
+  uploadedAt   DateTime @default(now())
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([userId])
+  @@index([userId, documentType])
 }

--- a/src/app/(private)/documents/page.tsx
+++ b/src/app/(private)/documents/page.tsx
@@ -1,0 +1,68 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+
+import { DocumentFilters } from '@/components/documents/document-filters'
+import { DocumentTable } from '@/components/documents/document-table'
+import { UploadDocumentDialog } from '@/components/documents/upload-document-dialog'
+
+interface DocumentsPageProps {
+  searchParams: Promise<{
+    search?: string
+    type?: string
+  }>
+}
+
+export default async function DocumentsPage({ searchParams }: DocumentsPageProps) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) redirect('/auth/login')
+
+  const params = await searchParams
+  const search = params.search || ''
+  const documentType = params.type || ''
+
+  const where: Record<string, unknown> = { userId: session.user.id }
+
+  if (search) {
+    where.fileName = { contains: search }
+  }
+
+  if (documentType) {
+    where.documentType = documentType
+  }
+
+  const documents = await prisma.document.findMany({
+    where,
+    orderBy: { uploadedAt: 'desc' },
+  })
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-2xl font-bold text-gray-900">Documents</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Upload and manage your financial documents.
+          </p>
+        </div>
+        <UploadDocumentDialog />
+      </div>
+
+      <DocumentFilters search={search} documentType={documentType} />
+
+      <DocumentTable
+        documents={documents.map(doc => ({
+          id: doc.id,
+          fileName: doc.fileName,
+          fileSize: doc.fileSize,
+          mimeType: doc.mimeType,
+          documentType: doc.documentType,
+          tags: doc.tags,
+          description: doc.description,
+          uploadedAt: doc.uploadedAt.toISOString(),
+        }))}
+      />
+    </div>
+  )
+}

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,0 +1,106 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { readFile, unlink } from 'fs/promises'
+import { join } from 'path'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const { id } = await params
+
+  const document = await prisma.document.findFirst({
+    where: { id, userId: session.user.id },
+  })
+
+  if (!document) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  try {
+    const filePath = join(process.cwd(), 'data', 'uploads', document.fileUrl)
+    const fileBuffer = await readFile(filePath)
+
+    return new Response(fileBuffer, {
+      headers: {
+        'Content-Type': document.mimeType,
+        'Content-Disposition': `inline; filename="${document.fileName}"`,
+      },
+    })
+  } catch {
+    return new Response('File not found', { status: 404 })
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const document = await prisma.document.findFirst({
+    where: { id, userId: session.user.id },
+  })
+
+  if (!document) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const body = await request.json()
+  const data: Record<string, unknown> = {}
+
+  if (body.documentType !== undefined) data.documentType = body.documentType
+  if (body.tags !== undefined) data.tags = body.tags
+  if (body.description !== undefined) data.description = body.description
+
+  const updated = await prisma.document.update({
+    where: { id },
+    data,
+  })
+
+  return NextResponse.json({ document: updated })
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const document = await prisma.document.findFirst({
+    where: { id, userId: session.user.id },
+  })
+
+  if (!document) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  // Delete the file from disk
+  try {
+    const filePath = join(process.cwd(), 'data', 'uploads', document.fileUrl)
+    await unlink(filePath)
+  } catch {
+    // File may already be deleted — continue with DB cleanup
+  }
+
+  await prisma.document.delete({ where: { id } })
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,0 +1,32 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = request.nextUrl
+  const search = searchParams.get('search') || ''
+  const documentType = searchParams.get('type') || ''
+
+  const where: Record<string, unknown> = { userId: session.user.id }
+
+  if (search) {
+    where.fileName = { contains: search }
+  }
+
+  if (documentType) {
+    where.documentType = documentType
+  }
+
+  const documents = await prisma.document.findMany({
+    where,
+    orderBy: { uploadedAt: 'desc' },
+  })
+
+  return NextResponse.json({ documents })
+}

--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -1,0 +1,90 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+import { prisma } from '@/lib/prisma'
+
+const ALLOWED_TYPES = new Set([
+  'application/pdf',
+  'text/markdown',
+  'text/x-markdown',
+  'text/csv',
+  'text/plain',
+  'image/jpeg',
+  'image/png',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+])
+
+const ALLOWED_EXTENSIONS = new Set([
+  'pdf', 'md', 'csv', 'txt', 'jpg', 'jpeg', 'png', 'xlsx', 'xls',
+])
+
+const DOCUMENT_TYPES = new Set([
+  'statement', 'tax', 'investment', 'receipt', 'other',
+])
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const formData = await request.formData()
+  const file = formData.get('file') as File
+  const documentType = (formData.get('documentType') as string) || 'other'
+  const description = (formData.get('description') as string) || null
+  const tags = (formData.get('tags') as string) || null
+
+  if (!file) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+  }
+
+  if (!DOCUMENT_TYPES.has(documentType)) {
+    return NextResponse.json(
+      { error: 'Invalid document type. Allowed: statement, tax, investment, receipt, other' },
+      { status: 400 },
+    )
+  }
+
+  const extension = file.name.split('.').pop()?.toLowerCase()
+
+  if (!ALLOWED_TYPES.has(file.type) && (!extension || !ALLOWED_EXTENSIONS.has(extension))) {
+    return NextResponse.json(
+      { error: 'Unsupported file type. Allowed: PDF, Markdown, CSV, Text, Images (JPG/PNG), Excel (XLSX/XLS)' },
+      { status: 400 },
+    )
+  }
+
+  const maxSize = 10 * 1024 * 1024
+  if (file.size > maxSize) {
+    return NextResponse.json({ error: 'File size exceeds 10MB limit' }, { status: 400 })
+  }
+
+  const timestamp = Date.now()
+  const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_')
+  const relPath = `documents/${session.user.id}/${timestamp}_${sanitizedFileName}`
+
+  const uploadDir = join(process.cwd(), 'data', 'uploads', 'documents', session.user.id)
+  await mkdir(uploadDir, { recursive: true })
+
+  const fullPath = join(process.cwd(), 'data', 'uploads', relPath)
+  const buffer = Buffer.from(await file.arrayBuffer())
+  await writeFile(fullPath, buffer)
+
+  const document = await prisma.document.create({
+    data: {
+      userId: session.user.id,
+      fileName: sanitizedFileName,
+      fileUrl: relPath,
+      fileSize: file.size,
+      mimeType: file.type || 'application/octet-stream',
+      documentType,
+      description,
+      tags,
+    },
+  })
+
+  return NextResponse.json({ success: true, document })
+}

--- a/src/components/documents/document-filters.tsx
+++ b/src/components/documents/document-filters.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useState } from 'react'
+import { Search } from 'lucide-react'
+
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { DOCUMENT_TYPES } from './document-types'
+
+interface DocumentFiltersProps {
+  search: string
+  documentType: string
+}
+
+export function DocumentFilters({ search, documentType }: DocumentFiltersProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [searchValue, setSearchValue] = useState(search)
+
+  const updateParam = useCallback((key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (value) {
+      params.set(key, value)
+    } else {
+      params.delete(key)
+    }
+    router.push(`/documents?${params.toString()}`)
+  }, [router, searchParams])
+
+  function handleSearchSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    updateParam('search', searchValue)
+  }
+
+  return (
+    <div className="mt-6 space-y-4">
+      <div className="flex flex-wrap items-center gap-4">
+        <form onSubmit={handleSearchSubmit} className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            type="text"
+            placeholder="Search documents..."
+            value={searchValue}
+            onChange={e => setSearchValue(e.target.value)}
+            className="pl-10"
+          />
+        </form>
+
+        <div className="flex gap-1">
+          <Button
+            variant={!documentType ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => updateParam('type', '')}
+          >
+            All
+          </Button>
+          {DOCUMENT_TYPES.map(type => (
+            <Button
+              key={type.value}
+              variant={documentType === type.value ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => updateParam('type', type.value === documentType ? '' : type.value)}
+            >
+              {type.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/documents/document-table.tsx
+++ b/src/components/documents/document-table.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import {
+  FileText,
+  Image,
+  FileSpreadsheet,
+  File,
+  Download,
+  Trash2,
+  Tag,
+  MoreHorizontal,
+} from 'lucide-react'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  type DocumentItem,
+  formatFileSize,
+  getDocumentTypeColor,
+  getFileIcon,
+} from './document-types'
+
+interface DocumentTableProps {
+  documents: DocumentItem[]
+}
+
+function FileIcon({ mimeType }: { mimeType: string }) {
+  const type = getFileIcon(mimeType)
+  const className = 'h-5 w-5 text-gray-400'
+
+  switch (type) {
+    case 'pdf':
+      return <FileText className={className} />
+    case 'image':
+      return <Image className={className} />
+    case 'spreadsheet':
+      return <FileSpreadsheet className={className} />
+    default:
+      return <File className={className} />
+  }
+}
+
+function DocumentRow({ document }: { document: DocumentItem }) {
+  const router = useRouter()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const uploadDate = new Date(document.uploadedAt)
+  const formattedDate = uploadDate.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+
+  function handleView() {
+    window.open(`/api/documents/${document.id}`, '_blank')
+  }
+
+  function handleDownload() {
+    const link = window.document.createElement('a')
+    link.href = `/api/documents/${document.id}`
+    link.download = document.fileName
+    link.click()
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Delete "${document.fileName}"?`)) return
+
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/documents/${document.id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Delete failed')
+
+      toast.success('Document deleted')
+      router.refresh()
+    } catch {
+      toast.error('Failed to delete document')
+    } finally {
+      setDeleting(false)
+      setMenuOpen(false)
+    }
+  }
+
+  const tags = document.tags?.split(',').map(t => t.trim()).filter(Boolean) ?? []
+
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="whitespace-nowrap px-6 py-4">
+        <div className="flex items-center gap-3">
+          <FileIcon mimeType={document.mimeType} />
+          <div className="min-w-0">
+            <button
+              onClick={handleView}
+              className="block truncate text-sm font-medium text-gray-900 hover:text-violet-600 text-left max-w-xs"
+              title={document.fileName}
+            >
+              {document.fileName}
+            </button>
+            {document.description && (
+              <p className="truncate text-xs text-gray-500 max-w-xs">{document.description}</p>
+            )}
+          </div>
+        </div>
+      </td>
+      <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+        {formattedDate}
+      </td>
+      <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+        {formatFileSize(document.fileSize)}
+      </td>
+      <td className="whitespace-nowrap px-6 py-4">
+        <span className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${getDocumentTypeColor(document.documentType)}`}>
+          {document.documentType}
+        </span>
+      </td>
+      <td className="px-6 py-4">
+        <div className="flex flex-wrap gap-1">
+          {tags.map(tag => (
+            <span
+              key={tag}
+              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+            >
+              <Tag className="h-3 w-3" />
+              {tag}
+            </span>
+          ))}
+        </div>
+      </td>
+      <td className="whitespace-nowrap px-6 py-4 text-right">
+        <div className="relative inline-block">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => setMenuOpen(prev => !prev)}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+
+          {menuOpen && (
+            <>
+              <div
+                className="fixed inset-0 z-40"
+                onClick={() => setMenuOpen(false)}
+              />
+              <div className="absolute right-0 z-50 mt-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+                <button
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => {
+                    setMenuOpen(false)
+                    handleView()
+                  }}
+                >
+                  <FileText className="h-4 w-4" />
+                  View
+                </button>
+                <button
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => {
+                    setMenuOpen(false)
+                    handleDownload()
+                  }}
+                >
+                  <Download className="h-4 w-4" />
+                  Download
+                </button>
+                <button
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  {deleting ? 'Deleting...' : 'Delete'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+export function DocumentTable({ documents }: DocumentTableProps) {
+  if (documents.length === 0) {
+    return (
+      <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-white p-12 text-center">
+        <FileText className="mx-auto h-12 w-12 text-gray-300" />
+        <p className="mt-4 text-sm text-gray-500">
+          No documents found. Upload a document to get started.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              File
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Uploaded
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Size
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Type
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Tags
+            </th>
+            <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {documents.map(doc => (
+            <DocumentRow key={doc.id} document={doc} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/documents/document-types.ts
+++ b/src/components/documents/document-types.ts
@@ -1,0 +1,50 @@
+export const DOCUMENT_TYPES = [
+  { value: 'statement', label: 'Statement' },
+  { value: 'tax', label: 'Tax' },
+  { value: 'investment', label: 'Investment' },
+  { value: 'receipt', label: 'Receipt' },
+  { value: 'other', label: 'Other' },
+] as const
+
+export type DocumentType = typeof DOCUMENT_TYPES[number]['value']
+
+export interface DocumentItem {
+  id: string
+  fileName: string
+  fileSize: number
+  mimeType: string
+  documentType: string
+  tags: string | null
+  description: string | null
+  uploadedAt: string
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  const size = bytes / Math.pow(1024, i)
+  return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+export function getDocumentTypeColor(type: string): string {
+  switch (type) {
+    case 'statement':
+      return 'bg-blue-100 text-blue-700'
+    case 'tax':
+      return 'bg-purple-100 text-purple-700'
+    case 'investment':
+      return 'bg-green-100 text-green-700'
+    case 'receipt':
+      return 'bg-amber-100 text-amber-700'
+    default:
+      return 'bg-gray-100 text-gray-700'
+  }
+}
+
+export function getFileIcon(mimeType: string): 'pdf' | 'image' | 'spreadsheet' | 'text' {
+  if (mimeType === 'application/pdf') return 'pdf'
+  if (mimeType.startsWith('image/')) return 'image'
+  if (mimeType.includes('spreadsheet') || mimeType.includes('excel')) return 'spreadsheet'
+  return 'text'
+}

--- a/src/components/documents/upload-document-dialog.tsx
+++ b/src/components/documents/upload-document-dialog.tsx
@@ -1,0 +1,254 @@
+'use client'
+
+import { useState, useRef, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Upload, Loader2, X, FileUp } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+import { DOCUMENT_TYPES } from './document-types'
+
+export function UploadDocumentDialog() {
+  const [open, setOpen] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [dragActive, setDragActive] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [documentType, setDocumentType] = useState('other')
+  const [description, setDescription] = useState('')
+  const [tags, setTags] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const router = useRouter()
+
+  function resetForm() {
+    setSelectedFile(null)
+    setDocumentType('other')
+    setDescription('')
+    setTags('')
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  function handleClose() {
+    if (!uploading) {
+      setOpen(false)
+      resetForm()
+    }
+  }
+
+  const handleDrag = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.type === 'dragenter' || e.type === 'dragover') {
+      setDragActive(true)
+    } else if (e.type === 'dragleave') {
+      setDragActive(false)
+    }
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragActive(false)
+
+    const files = e.dataTransfer.files
+    if (files && files.length > 0) {
+      setSelectedFile(files[0])
+    }
+  }, [])
+
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files
+    if (files && files.length > 0) {
+      setSelectedFile(files[0])
+    }
+  }
+
+  async function handleUpload() {
+    if (!selectedFile) return
+
+    setUploading(true)
+    const toastId = toast.loading('Uploading document...', {
+      description: selectedFile.name,
+    })
+
+    try {
+      const formData = new FormData()
+      formData.append('file', selectedFile)
+      formData.append('documentType', documentType)
+      if (description.trim()) formData.append('description', description.trim())
+      if (tags.trim()) formData.append('tags', tags.trim())
+
+      const res = await fetch('/api/documents/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error || 'Upload failed')
+      }
+
+      toast.success('Document uploaded!', {
+        id: toastId,
+        description: selectedFile.name,
+      })
+
+      handleClose()
+      router.refresh()
+    } catch (error) {
+      toast.error('Upload failed', {
+        id: toastId,
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <Upload className="h-4 w-4" />
+        Upload Document
+      </Button>
+
+      <Sheet open={open} onOpenChange={handleClose}>
+        <SheetContent className="overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Upload Document</SheetTitle>
+            <SheetDescription>
+              Upload a financial document to your library.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-6 space-y-6">
+            {/* Drop zone */}
+            <div
+              onDragEnter={handleDrag}
+              onDragLeave={handleDrag}
+              onDragOver={handleDrag}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
+                dragActive
+                  ? 'border-violet-400 bg-violet-50'
+                  : selectedFile
+                    ? 'border-green-300 bg-green-50'
+                    : 'border-gray-300 hover:border-gray-400 hover:bg-gray-50'
+              }`}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".pdf,.md,.csv,.txt,.jpg,.jpeg,.png,.xlsx,.xls"
+                onChange={handleFileSelect}
+                className="hidden"
+                disabled={uploading}
+              />
+
+              {selectedFile ? (
+                <div className="flex items-center gap-3">
+                  <FileUp className="h-8 w-8 text-green-500" />
+                  <div className="text-left">
+                    <p className="text-sm font-medium text-gray-900">{selectedFile.name}</p>
+                    <p className="text-xs text-gray-500">
+                      {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setSelectedFile(null)
+                      if (fileInputRef.current) fileInputRef.current.value = ''
+                    }}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <Upload className="h-8 w-8 text-gray-400" />
+                  <p className="mt-2 text-sm text-gray-600">
+                    Drop a file here or click to browse
+                  </p>
+                  <p className="mt-1 text-xs text-gray-400">
+                    PDF, Markdown, CSV, Text, Images, Excel (max 10MB)
+                  </p>
+                </>
+              )}
+            </div>
+
+            {/* Document type */}
+            <div className="space-y-2">
+              <Label>Document Type</Label>
+              <select
+                value={documentType}
+                onChange={e => setDocumentType(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {DOCUMENT_TYPES.map(type => (
+                  <option key={type.value} value={type.value}>
+                    {type.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-2">
+              <Label>Description (optional)</Label>
+              <Input
+                placeholder="Brief description of this document"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                disabled={uploading}
+              />
+            </div>
+
+            {/* Tags */}
+            <div className="space-y-2">
+              <Label>Tags (optional)</Label>
+              <Input
+                placeholder="e.g. 2024, business, q1"
+                value={tags}
+                onChange={e => setTags(e.target.value)}
+                disabled={uploading}
+              />
+              <p className="text-xs text-gray-400">Separate tags with commas</p>
+            </div>
+
+            {/* Upload button */}
+            <Button
+              onClick={handleUpload}
+              disabled={!selectedFile || uploading}
+              className="w-full"
+            >
+              {uploading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Uploading...
+                </>
+              ) : (
+                <>
+                  <Upload className="h-4 w-4" />
+                  Upload
+                </>
+              )}
+            </Button>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -7,6 +7,7 @@ import {
   Home,
   Receipt,
   FileText,
+  FolderOpen,
   MessageSquare,
   Settings,
   LogOut,
@@ -24,6 +25,7 @@ const navItems = [
   { href: '/dashboard', label: 'Dashboard', icon: Home },
   { href: '/transactions', label: 'Transactions', icon: Receipt },
   { href: '/statements', label: 'Statements', icon: FileText },
+  { href: '/documents', label: 'Documents', icon: FolderOpen },
 ]
 
 export function Navbar() {


### PR DESCRIPTION
## Summary
- New `Document` Prisma model with type (statement, tax, investment, receipt, other), tags, and metadata
- `/documents` page with file browser UI — search by name, filter by type
- Upload via drag & drop with document type selector, description, and tags
- View/download and delete documents via action menu
- API routes: `GET /api/documents`, `POST /api/documents/upload`, `GET/PATCH/DELETE /api/documents/[id]`
- "Documents" added to sidebar navigation

## Test plan
- [ ] Navigate to Documents page via sidebar
- [ ] Upload a PDF — appears in the document list
- [ ] Filter by document type (tax, receipt, etc.)
- [ ] Search by file name
- [ ] Click view/download actions
- [ ] Delete a document

🤖 Generated with [Claude Code](https://claude.com/claude-code)