### PR TITLE
feat: background jobs system with progress UI and SSE streaming

### DIFF
--- a/prisma/migrations/20260222021122_add_background_jobs/migration.sql
+++ b/prisma/migrations/20260222021122_add_background_jobs/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "Job" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "progress" INTEGER NOT NULL DEFAULT 0,
+    "totalItems" INTEGER NOT NULL DEFAULT 0,
+    "completedItems" INTEGER NOT NULL DEFAULT 0,
+    "error" TEXT,
+    "startedAt" DATETIME,
+    "completedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Job_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "JobItem" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "jobId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "error" TEXT,
+    "startedAt" DATETIME,
+    "completedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "JobItem_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Job" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Job_userId_idx" ON "Job"("userId");
+
+-- CreateIndex
+CREATE INDEX "JobItem_jobId_idx" ON "JobItem"("jobId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   chatTraces       ChatTrace[]
   plaidConnections PlaidConnection[]
   documents        Document[]
+  jobs             Job[]
 }
 
 model Session {
@@ -340,4 +341,42 @@ model Document {
 
   @@index([userId])
   @@index([userId, documentType])
+}
+
+// ============================================================
+// Background jobs
+// ============================================================
+
+model Job {
+  id             String    @id @default(cuid())
+  userId         String
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  type           String    // "file_processing", "reprocessing", "plaid_sync"
+  status         String    @default("pending") // pending, running, completed, failed
+  progress       Int       @default(0) // 0-100
+  totalItems     Int       @default(0)
+  completedItems Int       @default(0)
+  error          String?
+  startedAt      DateTime?
+  completedAt    DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  items JobItem[]
+
+  @@index([userId])
+}
+
+model JobItem {
+  id          String    @id @default(cuid())
+  jobId       String
+  job         Job       @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  fileName    String
+  status      String    @default("pending") // pending, running, completed, failed
+  error       String?
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([jobId])
 }

--- a/src/app/(private)/jobs/[id]/page.tsx
+++ b/src/app/(private)/jobs/[id]/page.tsx
@@ -1,0 +1,235 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { redirect, notFound } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+import {
+  formatJobType,
+  formatJobStatus,
+  formatDuration,
+} from '@/lib/jobs/job-types'
+import { JobDetailLive } from '@/components/jobs/job-detail-live'
+
+function formatTimestamp(date: Date): string {
+  return date.toISOString().replace('T', ' ').slice(0, 19)
+}
+
+export default async function JobDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) redirect('/auth/login')
+
+  const { id } = await params
+
+  const job = await prisma.job.findFirst({
+    where: { id, userId: session.user.id },
+    include: {
+      items: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!job) notFound()
+
+  const isActive = job.status === 'pending' || job.status === 'running'
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/jobs"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Jobs
+        </Link>
+      </div>
+
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="font-heading text-2xl font-bold text-gray-900">
+            {formatJobType(job.type)}
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Created {formatTimestamp(job.createdAt)}
+          </p>
+        </div>
+        <StatusBadge status={job.status} />
+      </div>
+
+      {/* Summary cards */}
+      <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <SummaryCard label="Status" value={formatJobStatus(job.status)} />
+        <SummaryCard label="Progress" value={`${job.progress}%`} />
+        <SummaryCard label="Items" value={`${job.completedItems}/${job.totalItems}`} />
+        <SummaryCard
+          label="Duration"
+          value={formatDuration(
+            job.startedAt?.toISOString() ?? null,
+            job.completedAt?.toISOString() ?? null,
+          )}
+        />
+      </div>
+
+      {job.error && (
+        <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-4">
+          <p className="text-sm font-medium text-red-800">Error</p>
+          <p className="mt-1 text-sm text-red-700">{job.error}</p>
+        </div>
+      )}
+
+      {/* Progress bar */}
+      <div className="mt-6">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+          <div
+            className={`h-full rounded-full transition-all duration-300 ${
+              job.status === 'failed' ? 'bg-red-500' : 'bg-violet-600'
+            }`}
+            style={{ width: `${job.progress}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Items list — live or static */}
+      {isActive ? (
+        <JobDetailLive
+          jobId={job.id}
+          initialItems={job.items.map(item => ({
+            id: item.id,
+            fileName: item.fileName,
+            status: item.status,
+            error: item.error,
+            startedAt: item.startedAt?.toISOString() ?? null,
+            completedAt: item.completedAt?.toISOString() ?? null,
+            createdAt: item.createdAt.toISOString(),
+          }))}
+        />
+      ) : (
+        <ItemsList
+          items={job.items.map(item => ({
+            id: item.id,
+            fileName: item.fileName,
+            status: item.status,
+            error: item.error,
+            startedAt: item.startedAt?.toISOString() ?? null,
+            completedAt: item.completedAt?.toISOString() ?? null,
+            createdAt: item.createdAt.toISOString(),
+          }))}
+        />
+      )}
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-gray-100 text-gray-700',
+    running: 'bg-blue-100 text-blue-700',
+    completed: 'bg-green-100 text-green-700',
+    failed: 'bg-red-100 text-red-700',
+  }
+
+  return (
+    <span
+      className={`inline-flex rounded-full px-3 py-1 text-sm font-medium ${styles[status] ?? styles.pending}`}
+    >
+      {formatJobStatus(status)}
+    </span>
+  )
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <p className="text-xs font-medium uppercase tracking-wider text-gray-500">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-gray-900">{value}</p>
+    </div>
+  )
+}
+
+interface ItemData {
+  id: string
+  fileName: string
+  status: string
+  error: string | null
+  startedAt: string | null
+  completedAt: string | null
+  createdAt: string
+}
+
+function ItemsList({ items }: { items: ItemData[] }) {
+  if (items.length === 0) {
+    return (
+      <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center">
+        <p className="text-sm text-gray-500">No items in this job.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-lg font-semibold text-gray-900">Items</h2>
+      <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                File
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Status
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Duration
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Error
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {items.map(item => (
+              <tr key={item.id} className="hover:bg-gray-50">
+                <td className="whitespace-nowrap px-6 py-3 text-sm text-gray-900">
+                  {item.fileName}
+                </td>
+                <td className="whitespace-nowrap px-6 py-3 text-sm">
+                  <ItemStatusBadge status={item.status} />
+                </td>
+                <td className="whitespace-nowrap px-6 py-3 text-right text-xs text-gray-500 font-mono">
+                  {formatDuration(item.startedAt, item.completedAt)}
+                </td>
+                <td className="max-w-xs truncate px-6 py-3 text-right text-xs text-red-500">
+                  {item.error ?? '--'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function ItemStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-gray-100 text-gray-700',
+    running: 'bg-blue-100 text-blue-700',
+    completed: 'bg-green-100 text-green-700',
+    failed: 'bg-red-100 text-red-700',
+  }
+
+  return (
+    <span
+      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${styles[status] ?? styles.pending}`}
+    >
+      {formatJobStatus(status)}
+    </span>
+  )
+}

--- a/src/app/(private)/jobs/page.tsx
+++ b/src/app/(private)/jobs/page.tsx
@@ -1,0 +1,138 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import Link from 'next/link'
+
+import {
+  formatJobType,
+  formatJobStatus,
+  formatDuration,
+} from '@/lib/jobs/job-types'
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-gray-100 text-gray-700',
+    running: 'bg-blue-100 text-blue-700',
+    completed: 'bg-green-100 text-green-700',
+    failed: 'bg-red-100 text-red-700',
+  }
+
+  return (
+    <span
+      className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${styles[status] ?? styles.pending}`}
+    >
+      {formatJobStatus(status)}
+    </span>
+  )
+}
+
+function formatTimestamp(date: Date): string {
+  return date.toISOString().replace('T', ' ').slice(0, 19)
+}
+
+export default async function JobsPage() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) redirect('/auth/login')
+
+  const jobs = await prisma.job.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+    include: {
+      _count: { select: { items: true } },
+    },
+  })
+
+  return (
+    <div>
+      <div>
+        <h1 className="font-heading text-2xl font-bold text-gray-900">Jobs</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Track background processing jobs and their progress.
+        </p>
+      </div>
+
+      <div className="mt-6">
+        {jobs.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-gray-300 bg-white p-12 text-center">
+            <p className="text-sm text-gray-500">
+              No jobs yet. Jobs are created when you upload files or trigger reprocessing.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Type
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Status
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Progress
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Items
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Duration
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Created
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {jobs.map(job => (
+                  <tr key={job.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                      <Link
+                        href={`/jobs/${job.id}`}
+                        className="hover:text-violet-600"
+                      >
+                        {formatJobType(job.type)}
+                      </Link>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <StatusBadge status={job.status} />
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <div className="flex items-center gap-2">
+                        <div className="h-1.5 w-24 overflow-hidden rounded-full bg-gray-200">
+                          <div
+                            className={`h-full rounded-full transition-all ${
+                              job.status === 'failed' ? 'bg-red-500' : 'bg-violet-600'
+                            }`}
+                            style={{ width: `${job.progress}%` }}
+                          />
+                        </div>
+                        <span className="text-xs text-gray-500 tabular-nums">
+                          {job.progress}%
+                        </span>
+                      </div>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-500">
+                      {job.completedItems}/{job.totalItems}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-right text-xs text-gray-500 font-mono">
+                      {formatDuration(
+                        job.startedAt?.toISOString() ?? null,
+                        job.completedAt?.toISOString() ?? null,
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-right text-xs text-gray-500 font-mono">
+                      {formatTimestamp(job.createdAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { Navbar } from '@/components/layout/navbar'
 import { Toaster } from '@/components/ui/sonner'
+import { FloatingJobIndicator } from '@/components/jobs/floating-job-indicator'
 
 export default async function PrivateLayout({
   children,
@@ -24,6 +25,7 @@ export default async function PrivateLayout({
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {children}
       </main>
+      <FloatingJobIndicator />
       <Toaster richColors position="bottom-right" />
     </div>
   )

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,53 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const job = await prisma.job.findFirst({
+    where: { id, userId: session.user.id },
+    include: {
+      items: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!job) {
+    return Response.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return Response.json({
+    job: {
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      progress: job.progress,
+      totalItems: job.totalItems,
+      completedItems: job.completedItems,
+      error: job.error,
+      startedAt: job.startedAt?.toISOString() ?? null,
+      completedAt: job.completedAt?.toISOString() ?? null,
+      createdAt: job.createdAt.toISOString(),
+      items: job.items.map(item => ({
+        id: item.id,
+        fileName: item.fileName,
+        status: item.status,
+        error: item.error,
+        startedAt: item.startedAt?.toISOString() ?? null,
+        completedAt: item.completedAt?.toISOString() ?? null,
+        createdAt: item.createdAt.toISOString(),
+      })),
+    },
+  })
+}

--- a/src/app/api/jobs/[id]/stream/route.ts
+++ b/src/app/api/jobs/[id]/stream/route.ts
@@ -1,0 +1,100 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const job = await prisma.job.findFirst({
+    where: { id, userId: session.user.id },
+  })
+
+  if (!job) {
+    return Response.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function sendEvent(data: Record<string, unknown>) {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(data)}\n\n`),
+        )
+      }
+
+      async function poll() {
+        try {
+          const current = await prisma.job.findFirst({
+            where: { id, userId: session!.user.id },
+            include: {
+              items: {
+                orderBy: { createdAt: 'asc' },
+                select: {
+                  id: true,
+                  fileName: true,
+                  status: true,
+                  error: true,
+                },
+              },
+            },
+          })
+
+          if (!current) {
+            sendEvent({ type: 'error', message: 'Job not found' })
+            controller.close()
+            return
+          }
+
+          sendEvent({
+            type: 'progress',
+            job: {
+              id: current.id,
+              status: current.status,
+              progress: current.progress,
+              totalItems: current.totalItems,
+              completedItems: current.completedItems,
+              error: current.error,
+              items: current.items,
+            },
+          })
+
+          if (current.status === 'completed' || current.status === 'failed') {
+            sendEvent({ type: 'done', status: current.status })
+            controller.close()
+            return
+          }
+
+          // Poll again in 2 seconds
+          setTimeout(poll, 2000)
+        } catch {
+          try {
+            controller.close()
+          } catch {
+            // Stream may already be closed
+          }
+        }
+      }
+
+      // Start polling
+      poll()
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/src/app/api/jobs/active/route.ts
+++ b/src/app/api/jobs/active/route.ts
@@ -1,0 +1,44 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const jobs = await prisma.job.findMany({
+    where: {
+      userId: session.user.id,
+      status: { in: ['pending', 'running'] },
+    },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      items: {
+        orderBy: { createdAt: 'asc' },
+        select: {
+          id: true,
+          fileName: true,
+          status: true,
+          error: true,
+        },
+      },
+    },
+  })
+
+  return Response.json({
+    jobs: jobs.map(j => ({
+      id: j.id,
+      type: j.type,
+      status: j.status,
+      progress: j.progress,
+      totalItems: j.totalItems,
+      completedItems: j.completedItems,
+      error: j.error,
+      startedAt: j.startedAt?.toISOString() ?? null,
+      createdAt: j.createdAt.toISOString(),
+      items: j.items,
+    })),
+  })
+}

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,0 +1,46 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const searchParams = request.nextUrl.searchParams
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '50', 10), 200)
+  const cursor = searchParams.get('cursor') ?? undefined
+
+  const jobs = await prisma.job.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' },
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    include: {
+      _count: { select: { items: true } },
+    },
+  })
+
+  const hasMore = jobs.length > limit
+  const items = hasMore ? jobs.slice(0, limit) : jobs
+  const nextCursor = hasMore ? items[items.length - 1]?.id : undefined
+
+  return Response.json({
+    jobs: items.map(j => ({
+      id: j.id,
+      type: j.type,
+      status: j.status,
+      progress: j.progress,
+      totalItems: j.totalItems,
+      completedItems: j.completedItems,
+      error: j.error,
+      startedAt: j.startedAt?.toISOString() ?? null,
+      completedAt: j.completedAt?.toISOString() ?? null,
+      createdAt: j.createdAt.toISOString(),
+      itemCount: j._count.items,
+    })),
+    nextCursor,
+  })
+}

--- a/src/components/jobs/floating-job-indicator.tsx
+++ b/src/components/jobs/floating-job-indicator.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, CheckCircle2, XCircle, ChevronUp, ChevronDown, ExternalLink } from 'lucide-react'
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+import { useActiveJobs } from '@/hooks/use-active-jobs'
+import { formatJobType } from '@/lib/jobs/job-types'
+import type { ActiveJob, JobItemSummary } from '@/lib/jobs/job-types'
+
+function JobItemStatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case 'running':
+      return <Loader2 className="h-3 w-3 animate-spin text-blue-500" />
+    case 'completed':
+      return <CheckCircle2 className="h-3 w-3 text-green-500" />
+    case 'failed':
+      return <XCircle className="h-3 w-3 text-red-500" />
+    default:
+      return <div className="h-3 w-3 rounded-full border border-gray-300" />
+  }
+}
+
+function JobItemRow({ item }: { item: JobItemSummary }) {
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <JobItemStatusIcon status={item.status} />
+      <span className="truncate text-xs text-gray-700">{item.fileName}</span>
+      {item.error && (
+        <span className="ml-auto shrink-0 text-xs text-red-500" title={item.error}>
+          Error
+        </span>
+      )}
+    </div>
+  )
+}
+
+function JobCard({ job }: { job: ActiveJob }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="border-t border-gray-100 first:border-t-0">
+      <button
+        type="button"
+        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-violet-600" />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-gray-900">
+            {formatJobType(job.type)}
+          </div>
+          <div className="text-xs text-gray-500">
+            {job.completedItems}/{job.totalItems} items
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-gray-200">
+            <div
+              className="h-full rounded-full bg-violet-600 transition-all duration-300"
+              style={{ width: `${job.progress}%` }}
+            />
+          </div>
+          <span className="text-xs text-gray-500 tabular-nums">
+            {job.progress}%
+          </span>
+          {expanded ? (
+            <ChevronUp className="h-3 w-3 text-gray-400" />
+          ) : (
+            <ChevronDown className="h-3 w-3 text-gray-400" />
+          )}
+        </div>
+      </button>
+      {expanded && job.items.length > 0 && (
+        <div className="border-t border-gray-100 bg-gray-50/50 px-4 py-2 max-h-48 overflow-y-auto">
+          {job.items.map(item => (
+            <JobItemRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function FloatingJobIndicator() {
+  const { jobs, loading } = useActiveJobs()
+  const [expanded, setExpanded] = useState(false)
+
+  // Don't render anything when there are no active jobs
+  if (loading || jobs.length === 0) return null
+
+  const totalCompleted = jobs.reduce((sum, j) => sum + j.completedItems, 0)
+  const totalItems = jobs.reduce((sum, j) => sum + j.totalItems, 0)
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      {/* Expanded panel */}
+      <div
+        className={cn(
+          'mb-2 w-80 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg transition-all duration-200',
+          expanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0 border-0 shadow-none',
+        )}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-2">
+          <span className="text-sm font-medium text-gray-900">Active Jobs</span>
+          <Link
+            href="/jobs"
+            className="inline-flex items-center gap-1 text-xs text-violet-600 hover:text-violet-700"
+          >
+            View all
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        </div>
+        <div className="max-h-72 overflow-y-auto">
+          {jobs.map(job => (
+            <JobCard key={job.id} job={job} />
+          ))}
+        </div>
+      </div>
+
+      {/* Floating badge */}
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 rounded-full bg-violet-600 px-4 py-2.5 text-white shadow-lg hover:bg-violet-700 transition-colors"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="text-sm font-medium">
+          Processing {totalCompleted}/{totalItems} files
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/src/components/jobs/job-detail-live.tsx
+++ b/src/components/jobs/job-detail-live.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Loader2, CheckCircle2, XCircle } from 'lucide-react'
+
+import { formatJobStatus, formatDuration } from '@/lib/jobs/job-types'
+import type { JobItemDetail } from '@/lib/jobs/job-types'
+
+interface JobDetailLiveProps {
+  jobId: string
+  initialItems: JobItemDetail[]
+}
+
+export function JobDetailLive({ jobId, initialItems }: JobDetailLiveProps) {
+  const [items, setItems] = useState<JobItemDetail[]>(initialItems)
+  const [connected, setConnected] = useState(false)
+
+  useEffect(() => {
+    const eventSource = new EventSource(`/api/jobs/${jobId}/stream`)
+
+    eventSource.onopen = () => {
+      setConnected(true)
+    }
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        if (data.type === 'progress' && data.job?.items) {
+          setItems(data.job.items.map((item: { id: string; fileName: string; status: string; error: string | null }) => ({
+            id: item.id,
+            fileName: item.fileName,
+            status: item.status,
+            error: item.error,
+            startedAt: null,
+            completedAt: null,
+            createdAt: '',
+          })))
+        }
+        if (data.type === 'done') {
+          eventSource.close()
+          // Reload the page to get the final server-rendered state
+          window.location.reload()
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+
+    eventSource.onerror = () => {
+      setConnected(false)
+      eventSource.close()
+    }
+
+    return () => {
+      eventSource.close()
+    }
+  }, [jobId])
+
+  if (items.length === 0) {
+    return (
+      <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center">
+        <p className="text-sm text-gray-500">No items in this job.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Items</h2>
+        {connected && (
+          <span className="inline-flex items-center gap-1.5 text-xs text-green-600">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
+            Live
+          </span>
+        )}
+      </div>
+      <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                File
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Status
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Duration
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                Error
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {items.map(item => (
+              <tr key={item.id} className="hover:bg-gray-50">
+                <td className="whitespace-nowrap px-6 py-3 text-sm text-gray-900">
+                  <div className="flex items-center gap-2">
+                    <ItemStatusIcon status={item.status} />
+                    {item.fileName}
+                  </div>
+                </td>
+                <td className="whitespace-nowrap px-6 py-3 text-sm">
+                  <ItemStatusBadge status={item.status} />
+                </td>
+                <td className="whitespace-nowrap px-6 py-3 text-right text-xs text-gray-500 font-mono">
+                  {formatDuration(item.startedAt, item.completedAt)}
+                </td>
+                <td className="max-w-xs truncate px-6 py-3 text-right text-xs text-red-500">
+                  {item.error ?? '--'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function ItemStatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case 'running':
+      return <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+    case 'completed':
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-red-500" />
+    default:
+      return <div className="h-4 w-4 rounded-full border-2 border-gray-300" />
+  }
+}
+
+function ItemStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-gray-100 text-gray-700',
+    running: 'bg-blue-100 text-blue-700',
+    completed: 'bg-green-100 text-green-700',
+    failed: 'bg-red-100 text-red-700',
+  }
+
+  return (
+    <span
+      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${styles[status] ?? styles.pending}`}
+    >
+      {formatJobStatus(status)}
+    </span>
+  )
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -13,6 +13,7 @@ import {
   LogOut,
   Menu,
   X,
+  ListChecks,
 } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -26,6 +27,7 @@ const navItems = [
   { href: '/transactions', label: 'Transactions', icon: Receipt },
   { href: '/statements', label: 'Statements', icon: FileText },
   { href: '/documents', label: 'Documents', icon: FolderOpen },
+  { href: '/jobs', label: 'Jobs', icon: ListChecks },
 ]
 
 export function Navbar() {

--- a/src/hooks/use-active-jobs.ts
+++ b/src/hooks/use-active-jobs.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+import type { ActiveJob } from '@/lib/jobs/job-types'
+
+export function useActiveJobs(pollIntervalMs = 3000) {
+  const [jobs, setJobs] = useState<ActiveJob[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchActiveJobs = useCallback(async () => {
+    try {
+      const res = await fetch('/api/jobs/active')
+      if (!res.ok) return
+      const data = await res.json()
+      setJobs(data.jobs ?? [])
+    } catch {
+      // Silently ignore fetch errors
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchActiveJobs()
+
+    const interval = setInterval(fetchActiveJobs, pollIntervalMs)
+    return () => clearInterval(interval)
+  }, [fetchActiveJobs, pollIntervalMs])
+
+  return { jobs, loading, refetch: fetchActiveJobs }
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -1,0 +1,98 @@
+export interface JobSummary {
+  id: string
+  type: string
+  status: string
+  progress: number
+  totalItems: number
+  completedItems: number
+  error: string | null
+  startedAt: string | null
+  completedAt: string | null
+  createdAt: string
+  itemCount: number
+}
+
+export interface JobItemSummary {
+  id: string
+  fileName: string
+  status: string
+  error: string | null
+}
+
+export interface JobDetail {
+  id: string
+  type: string
+  status: string
+  progress: number
+  totalItems: number
+  completedItems: number
+  error: string | null
+  startedAt: string | null
+  completedAt: string | null
+  createdAt: string
+  items: JobItemDetail[]
+}
+
+export interface JobItemDetail {
+  id: string
+  fileName: string
+  status: string
+  error: string | null
+  startedAt: string | null
+  completedAt: string | null
+  createdAt: string
+}
+
+export interface ActiveJob {
+  id: string
+  type: string
+  status: string
+  progress: number
+  totalItems: number
+  completedItems: number
+  error: string | null
+  startedAt: string | null
+  createdAt: string
+  items: JobItemSummary[]
+}
+
+export const JOB_TYPE_LABELS: Record<string, string> = {
+  file_processing: 'File Processing',
+  reprocessing: 'Reprocessing',
+  plaid_sync: 'Plaid Sync',
+}
+
+export const JOB_STATUS_LABELS: Record<string, string> = {
+  pending: 'Pending',
+  running: 'Running',
+  completed: 'Completed',
+  failed: 'Failed',
+}
+
+export function formatJobType(type: string): string {
+  return JOB_TYPE_LABELS[type] ?? type
+}
+
+export function formatJobStatus(status: string): string {
+  return JOB_STATUS_LABELS[status] ?? status
+}
+
+export function formatDuration(start: string | null, end: string | null): string {
+  if (!start) return '--'
+
+  const startTime = new Date(start).getTime()
+  const endTime = end ? new Date(end).getTime() : Date.now()
+  const diffMs = endTime - startTime
+
+  if (diffMs < 1000) return '<1s'
+  if (diffMs < 60000) return `${Math.round(diffMs / 1000)}s`
+  if (diffMs < 3600000) {
+    const mins = Math.floor(diffMs / 60000)
+    const secs = Math.round((diffMs % 60000) / 1000)
+    return `${mins}m ${secs}s`
+  }
+
+  const hours = Math.floor(diffMs / 3600000)
+  const mins = Math.round((diffMs % 3600000) / 60000)
+  return `${hours}h ${mins}m`
+}


### PR DESCRIPTION
## Summary
- New `Job` and `JobItem` Prisma models for tracking background tasks
- API routes: list jobs, active jobs, job detail, SSE stream for real-time progress
- Floating job indicator (bottom-right) on all authenticated pages — shows active progress
- Jobs list page (`/jobs`) with historical runs, status badges, progress bars
- Job detail page with per-item status table and live SSE updates for active jobs
- Added "Jobs" to navigation

## Test plan
- [ ] Navigate to Jobs page — shows empty state or historical jobs
- [ ] When a background job is running, floating indicator appears in bottom-right
- [ ] Click floating indicator — expands to show per-job progress
- [ ] Click a job — detail page shows items with live updates via SSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)