### PR TITLE
refactor: consolidate upload directories into single uploads/{userId}/ folder

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -352,7 +352,7 @@ model Document {
   userId            String
   user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   fileName          String
-  fileUrl           String   // Relative path under data/uploads/documents/
+  fileUrl           String   // Relative path under data/uploads/ (e.g. {userId}/{timestamp}_{file})
   fileSize          Int
   mimeType          String
   documentType      String   @default("other") // statement | tax | investment | receipt | other

--- a/scripts/consolidate-uploads.ts
+++ b/scripts/consolidate-uploads.ts
@@ -1,0 +1,340 @@
+/**
+ * Migration script: Consolidate upload directories
+ *
+ * Moves all files from:
+ *   data/uploads/attachments/{userId}/
+ *   data/uploads/documents/{userId}/
+ *   data/uploads/statements/{userId}/
+ *
+ * Into a single flat directory:
+ *   data/uploads/{userId}/
+ *
+ * Also:
+ * - Creates Document records for orphan files (files without a DB entry)
+ * - Updates BankStatement.fileUrl and Document.fileUrl to the new paths
+ * - Deduplicates by content hash (SHA-256)
+ *
+ * Usage:
+ *   npx tsx scripts/consolidate-uploads.ts [--dry-run]
+ */
+
+import { PrismaClient } from '../src/generated/prisma/client'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { readdir, readFile, rename, mkdir, unlink, stat } from 'fs/promises'
+import { join, extname } from 'path'
+import { createHash } from 'crypto'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+const adapter = new PrismaBetterSqlite3({
+  url: process.env.DATABASE_URL || 'file:./data/openfinance.db',
+})
+const prisma = new PrismaClient({ adapter })
+
+const UPLOADS_BASE = join(process.cwd(), 'data', 'uploads')
+const LEGACY_DIRS = ['attachments', 'documents', 'statements'] as const
+
+interface FileInfo {
+  legacyRelPath: string // e.g. "attachments/userId/file.pdf"
+  newRelPath: string    // e.g. "userId/file.pdf"
+  fullPath: string
+  userId: string
+  fileName: string
+  hash: string
+  size: number
+}
+
+function log(msg: string) {
+  const prefix = DRY_RUN ? '[DRY RUN] ' : ''
+  console.log(`${prefix}${msg}`)
+}
+
+async function computeHash(filePath: string): Promise<string> {
+  const buffer = await readFile(filePath)
+  return createHash('sha256').update(buffer).digest('hex')
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path)
+    return s.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path)
+    return s.isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Scan legacy directories and collect file info.
+ */
+async function scanLegacyFiles(): Promise<FileInfo[]> {
+  const files: FileInfo[] = []
+
+  for (const legacyDir of LEGACY_DIRS) {
+    const legacyPath = join(UPLOADS_BASE, legacyDir)
+    if (!(await dirExists(legacyPath))) {
+      log(`Skipping ${legacyDir}/ — directory does not exist`)
+      continue
+    }
+
+    const userDirs = await readdir(legacyPath)
+    for (const userId of userDirs) {
+      const userPath = join(legacyPath, userId)
+      if (!(await dirExists(userPath))) continue
+
+      const fileNames = await readdir(userPath)
+      for (const fileName of fileNames) {
+        const fullPath = join(userPath, fileName)
+        if (!(await fileExists(fullPath))) continue
+
+        const legacyRelPath = `${legacyDir}/${userId}/${fileName}`
+        const newRelPath = `${userId}/${fileName}`
+        const hash = await computeHash(fullPath)
+        const fileStat = await stat(fullPath)
+
+        files.push({
+          legacyRelPath,
+          newRelPath,
+          fullPath,
+          userId,
+          fileName,
+          hash,
+          size: fileStat.size,
+        })
+      }
+    }
+  }
+
+  return files
+}
+
+/**
+ * Detect MIME type from file extension.
+ */
+function getMimeType(fileName: string): string {
+  const ext = extname(fileName).toLowerCase()
+  const mimeMap: Record<string, string> = {
+    '.pdf': 'application/pdf',
+    '.md': 'text/markdown',
+    '.csv': 'text/csv',
+    '.txt': 'text/plain',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    '.xls': 'application/vnd.ms-excel',
+  }
+  return mimeMap[ext] || 'application/octet-stream'
+}
+
+/**
+ * Detect document type from legacy directory.
+ */
+function getDocumentType(legacyDir: string): string {
+  if (legacyDir === 'statements') return 'statement'
+  return 'other'
+}
+
+async function main() {
+  log('=== Consolidate Upload Directories ===')
+  log(`Uploads base: ${UPLOADS_BASE}`)
+  log('')
+
+  // 1. Scan legacy files
+  log('Scanning legacy directories...')
+  const files = await scanLegacyFiles()
+  log(`Found ${files.length} files across legacy directories`)
+
+  if (files.length === 0) {
+    log('No files to migrate. Done.')
+    await prisma.$disconnect()
+    return
+  }
+
+  // 2. Deduplicate by content hash — keep the first occurrence
+  const seenHashes = new Map<string, FileInfo>() // hash -> first file
+  const duplicates: FileInfo[] = []
+  const unique: FileInfo[] = []
+
+  for (const file of files) {
+    const key = `${file.userId}:${file.hash}`
+    if (seenHashes.has(key)) {
+      duplicates.push(file)
+      log(`  Duplicate: ${file.legacyRelPath} (same as ${seenHashes.get(key)!.legacyRelPath})`)
+    } else {
+      seenHashes.set(key, file)
+      unique.push(file)
+    }
+  }
+
+  log(`${unique.length} unique files, ${duplicates.length} duplicates`)
+  log('')
+
+  // 3. Move unique files to new location
+  log('Moving files...')
+  for (const file of unique) {
+    const newFullPath = join(UPLOADS_BASE, file.newRelPath)
+    const newDir = join(UPLOADS_BASE, file.userId)
+
+    // Check if file already exists at new location
+    if (await fileExists(newFullPath)) {
+      log(`  Already exists: ${file.newRelPath}`)
+      continue
+    }
+
+    if (DRY_RUN) {
+      log(`  Would move: ${file.legacyRelPath} -> ${file.newRelPath}`)
+    } else {
+      await mkdir(newDir, { recursive: true })
+      await rename(file.fullPath, newFullPath)
+      log(`  Moved: ${file.legacyRelPath} -> ${file.newRelPath}`)
+    }
+  }
+  log('')
+
+  // 4. Update BankStatement.fileUrl records
+  log('Updating BankStatement records...')
+  const statements = await prisma.bankStatement.findMany({
+    select: { id: true, fileUrl: true, userId: true },
+  })
+
+  let statementsUpdated = 0
+  for (const stmt of statements) {
+    // Check if fileUrl starts with a legacy prefix
+    const legacyMatch = stmt.fileUrl.match(/^(attachments|documents|statements)\/(.+)$/)
+    if (legacyMatch) {
+      const newFileUrl = legacyMatch[2] // strip the legacy prefix
+      if (DRY_RUN) {
+        log(`  Would update statement ${stmt.id}: ${stmt.fileUrl} -> ${newFileUrl}`)
+      } else {
+        await prisma.bankStatement.update({
+          where: { id: stmt.id },
+          data: { fileUrl: newFileUrl },
+        })
+        log(`  Updated statement ${stmt.id}: ${stmt.fileUrl} -> ${newFileUrl}`)
+      }
+      statementsUpdated++
+    }
+  }
+  log(`Updated ${statementsUpdated} BankStatement records`)
+  log('')
+
+  // 5. Update Document.fileUrl records
+  log('Updating Document records...')
+  const documents = await prisma.document.findMany({
+    select: { id: true, fileUrl: true, userId: true },
+  })
+
+  let documentsUpdated = 0
+  for (const doc of documents) {
+    const legacyMatch = doc.fileUrl.match(/^(attachments|documents|statements)\/(.+)$/)
+    if (legacyMatch) {
+      const newFileUrl = legacyMatch[2]
+      if (DRY_RUN) {
+        log(`  Would update document ${doc.id}: ${doc.fileUrl} -> ${newFileUrl}`)
+      } else {
+        await prisma.document.update({
+          where: { id: doc.id },
+          data: { fileUrl: newFileUrl },
+        })
+        log(`  Updated document ${doc.id}: ${doc.fileUrl} -> ${newFileUrl}`)
+      }
+      documentsUpdated++
+    }
+  }
+  log(`Updated ${documentsUpdated} Document records`)
+  log('')
+
+  // 6. Create Document records for orphan files (files without a DB entry)
+  log('Checking for orphan files...')
+
+  // Reload documents with new paths
+  const allDocFileUrls = new Set(
+    (await prisma.document.findMany({ select: { fileUrl: true } }))
+      .map(d => d.fileUrl),
+  )
+  const allStmtFileUrls = new Set(
+    (await prisma.bankStatement.findMany({ select: { fileUrl: true } }))
+      .map(s => s.fileUrl),
+  )
+
+  let orphansCreated = 0
+  for (const file of unique) {
+    const relPath = file.newRelPath
+    if (allDocFileUrls.has(relPath) || allStmtFileUrls.has(relPath)) continue
+    // Also check legacy paths in case migration hasn't run on DB yet
+    if (allDocFileUrls.has(file.legacyRelPath) || allStmtFileUrls.has(file.legacyRelPath)) continue
+
+    const legacyDir = file.legacyRelPath.split('/')[0]
+    const documentType = getDocumentType(legacyDir)
+    const mimeType = getMimeType(file.fileName)
+
+    if (DRY_RUN) {
+      log(`  Would create Document for orphan: ${relPath} (type: ${documentType})`)
+    } else {
+      await prisma.document.create({
+        data: {
+          userId: file.userId,
+          fileName: file.fileName,
+          fileUrl: relPath,
+          fileSize: file.size,
+          mimeType,
+          documentType,
+          description: `Migrated from ${legacyDir}/`,
+        },
+      })
+      log(`  Created Document for orphan: ${relPath} (type: ${documentType})`)
+    }
+    orphansCreated++
+  }
+  log(`Created ${orphansCreated} Document records for orphan files`)
+  log('')
+
+  // 7. Clean up duplicates
+  if (duplicates.length > 0) {
+    log('Cleaning up duplicate files...')
+    for (const dup of duplicates) {
+      if (DRY_RUN) {
+        log(`  Would delete duplicate: ${dup.legacyRelPath}`)
+      } else {
+        try {
+          await unlink(dup.fullPath)
+          log(`  Deleted duplicate: ${dup.legacyRelPath}`)
+        } catch {
+          log(`  Could not delete: ${dup.legacyRelPath} (may already be moved)`)
+        }
+      }
+    }
+    log('')
+  }
+
+  // 8. Summary
+  log('=== Migration Summary ===')
+  log(`Files scanned: ${files.length}`)
+  log(`Unique files moved: ${unique.length}`)
+  log(`Duplicates removed: ${duplicates.length}`)
+  log(`BankStatement records updated: ${statementsUpdated}`)
+  log(`Document records updated: ${documentsUpdated}`)
+  log(`Orphan Document records created: ${orphansCreated}`)
+
+  if (DRY_RUN) {
+    log('')
+    log('This was a DRY RUN. No changes were made.')
+    log('Run without --dry-run to apply changes.')
+  }
+
+  await prisma.$disconnect()
+}
+
+main().catch((error) => {
+  console.error('Migration failed:', error)
+  process.exit(1)
+})

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -3,7 +3,7 @@ import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { readFile, unlink } from 'fs/promises'
-import { join } from 'path'
+import { getUploadFullPath } from '@/lib/upload-path'
 
 export async function GET(
   _request: NextRequest,
@@ -25,7 +25,7 @@ export async function GET(
   }
 
   try {
-    const filePath = join(process.cwd(), 'data', 'uploads', document.fileUrl)
+    const filePath = getUploadFullPath(document.fileUrl)
     const fileBuffer = await readFile(filePath)
 
     return new Response(fileBuffer, {
@@ -94,7 +94,7 @@ export async function DELETE(
 
   // Delete the file from disk
   try {
-    const filePath = join(process.cwd(), 'data', 'uploads', document.fileUrl)
+    const filePath = getUploadFullPath(document.fileUrl)
     await unlink(filePath)
   } catch {
     // File may already be deleted — continue with DB cleanup

--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -1,10 +1,10 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-import { writeFile, mkdir } from 'fs/promises'
-import { join } from 'path'
+import { writeFile } from 'fs/promises'
 import { prisma } from '@/lib/prisma'
 import { classifyByFilename } from '@/lib/services/document-classifier'
+import { prepareUpload } from '@/lib/upload-path'
 
 const ALLOWED_TYPES = new Set([
   'application/pdf',
@@ -68,14 +68,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'File size exceeds 10MB limit' }, { status: 400 })
   }
 
-  const timestamp = Date.now()
-  const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_')
-  const relPath = `documents/${session.user.id}/${timestamp}_${sanitizedFileName}`
+  const { relPath, fullPath, sanitizedFileName } = await prepareUpload(session.user.id, file.name)
 
-  const uploadDir = join(process.cwd(), 'data', 'uploads', 'documents', session.user.id)
-  await mkdir(uploadDir, { recursive: true })
-
-  const fullPath = join(process.cwd(), 'data', 'uploads', relPath)
   const buffer = Buffer.from(await file.arrayBuffer())
   await writeFile(fullPath, buffer)
 

--- a/src/app/api/process-statement/route.ts
+++ b/src/app/api/process-statement/route.ts
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 import { readFile } from 'fs/promises'
-import { join } from 'path'
+import { getUploadFullPath } from '@/lib/upload-path'
 import { processStatement } from '@/lib/services/statement-processor'
 import { prisma } from '@/lib/prisma'
 
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
   try {
     // Read PDF from disk
     await addLog(job.id, ++logSeq, 'info', 'Extracting text from PDF')
-    const fullPath = join(process.cwd(), 'data', 'uploads', filePath)
+    const fullPath = getUploadFullPath(filePath)
     const pdfBuffer = await readFile(fullPath)
 
     // Extract text from PDF

--- a/src/app/api/statements/[id]/pdf/route.ts
+++ b/src/app/api/statements/[id]/pdf/route.ts
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { prisma } from '@/lib/prisma'
 import { readFile } from 'fs/promises'
-import { join } from 'path'
+import { getUploadFullPath } from '@/lib/upload-path'
 
 export async function GET(
   _request: Request,
@@ -25,7 +25,7 @@ export async function GET(
   }
 
   try {
-    const filePath = join(process.cwd(), 'data', 'uploads', statement.fileUrl)
+    const filePath = getUploadFullPath(statement.fileUrl)
     const fileBuffer = await readFile(filePath)
 
     return new Response(fileBuffer, {

--- a/src/app/api/statements/import/route.ts
+++ b/src/app/api/statements/import/route.ts
@@ -1,9 +1,9 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-import { writeFile, mkdir } from 'fs/promises'
-import { join } from 'path'
+import { writeFile } from 'fs/promises'
 import { prisma } from '@/lib/prisma'
+import { prepareUpload } from '@/lib/upload-path'
 
 export async function POST(request: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -36,20 +36,8 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const timestamp = Date.now()
-  const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_')
-  const relPath = `statements/${session.user.id}/${timestamp}_${sanitizedFileName}`
+  const { relPath, fullPath, sanitizedFileName } = await prepareUpload(session.user.id, file.name)
 
-  const uploadDir = join(
-    process.cwd(),
-    'data',
-    'uploads',
-    'statements',
-    session.user.id,
-  )
-  await mkdir(uploadDir, { recursive: true })
-
-  const fullPath = join(process.cwd(), 'data', 'uploads', relPath)
   const buffer = Buffer.from(await file.arrayBuffer())
   await writeFile(fullPath, buffer)
 

--- a/src/app/api/upload/bulk/route.ts
+++ b/src/app/api/upload/bulk/route.ts
@@ -1,8 +1,8 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-import { writeFile, mkdir } from 'fs/promises'
-import { join } from 'path'
+import { writeFile } from 'fs/promises'
+import { prepareUpload } from '@/lib/upload-path'
 import JSZip from 'jszip'
 
 interface UploadedFile {
@@ -16,14 +16,8 @@ async function savePdf(
   fileName: string,
   userId: string,
 ): Promise<UploadedFile> {
-  const timestamp = Date.now()
-  const sanitizedFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_')
-  const relPath = `statements/${userId}/${timestamp}_${sanitizedFileName}`
+  const { relPath, fullPath, sanitizedFileName } = await prepareUpload(userId, fileName)
 
-  const uploadDir = join(process.cwd(), 'data', 'uploads', 'statements', userId)
-  await mkdir(uploadDir, { recursive: true })
-
-  const fullPath = join(process.cwd(), 'data', 'uploads', relPath)
   await writeFile(fullPath, buffer)
 
   return {

--- a/src/lib/services/statement-processor.ts
+++ b/src/lib/services/statement-processor.ts
@@ -6,7 +6,7 @@ import {
 } from 'openai/resources/chat/completions.mjs'
 import { reconcileProvisionalTransactions } from '@/lib/services/plaid-sync'
 import { readFile } from 'fs/promises'
-import { join } from 'path'
+import { getUploadFullPath } from '@/lib/upload-path'
 
 // pdf-parse v1 has no proper ESM/TS types — use require
 const pdfParse = require('pdf-parse')
@@ -48,7 +48,7 @@ export async function processStatementById(
     }
 
     // Read PDF from disk
-    const fullPath = join(process.cwd(), 'data', 'uploads', statement.fileUrl)
+    const fullPath = getUploadFullPath(statement.fileUrl)
     const pdfBuffer = await readFile(fullPath)
     const pdfData = await pdfParse(pdfBuffer)
     const pdfText: string = pdfData.text

--- a/src/lib/upload-path.ts
+++ b/src/lib/upload-path.ts
@@ -1,0 +1,52 @@
+import { join } from 'path'
+import { mkdir } from 'fs/promises'
+
+/**
+ * Base directory for all file uploads.
+ * All files are stored flat under data/uploads/{userId}/.
+ */
+const UPLOADS_BASE = join(process.cwd(), 'data', 'uploads')
+
+/**
+ * Returns the absolute directory path for a user's uploads.
+ * e.g. /app/data/uploads/{userId}
+ */
+export function getUserUploadDir(userId: string): string {
+  return join(UPLOADS_BASE, userId)
+}
+
+/**
+ * Returns the relative path for a new upload (relative to data/uploads/).
+ * e.g. {userId}/{timestamp}_{sanitizedFileName}
+ */
+export function getUploadRelPath(userId: string, fileName: string): string {
+  const timestamp = Date.now()
+  const sanitized = fileName.replace(/[^a-zA-Z0-9.-]/g, '_')
+  return `${userId}/${timestamp}_${sanitized}`
+}
+
+/**
+ * Returns the absolute path for a file given its relative path.
+ * e.g. /app/data/uploads/{userId}/{timestamp}_{file.pdf}
+ */
+export function getUploadFullPath(relPath: string): string {
+  return join(UPLOADS_BASE, relPath)
+}
+
+/**
+ * Ensures the user's upload directory exists, then returns paths for a new file.
+ */
+export async function prepareUpload(userId: string, fileName: string): Promise<{
+  relPath: string
+  fullPath: string
+  sanitizedFileName: string
+}> {
+  const dir = getUserUploadDir(userId)
+  await mkdir(dir, { recursive: true })
+
+  const sanitizedFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_')
+  const relPath = getUploadRelPath(userId, fileName)
+  const fullPath = getUploadFullPath(relPath)
+
+  return { relPath, fullPath, sanitizedFileName }
+}


### PR DESCRIPTION
## Summary
- Consolidates three separate upload directories (`attachments/`, `documents/`, `statements/`) into a single flat `uploads/{userId}/` folder
- Adds unified `upload-path.ts` module with helpers: `getUserUploadDir()`, `getUploadRelPath()`, `getUploadFullPath()`, `prepareUpload()`
- Updates all upload API routes, file-serving routes, and statement processing to use the new unified paths
- Includes migration script (`scripts/consolidate-uploads.ts`) to move existing files and create missing Document records

Closes NAN-443

## Test plan
- [ ] Upload a file via statements — verify it goes to `data/uploads/{userId}/`
- [ ] Upload a file via documents — verify same directory
- [ ] Upload a file via chat — verify same directory
- [ ] Verify PDF viewer still serves files correctly
- [ ] Run migration script with `--dry-run` on production data

🤖 Generated with [Claude Code](https://claude.com/claude-code)