### PR TITLE
feat: CI build step, merge queue trigger, and merge rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,22 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   DATABASE_URL: 'file:./data/openfinance.db'
   BETTER_AUTH_SECRET: 'ci-test-secret-not-for-production'
   BETTER_AUTH_URL: 'http://localhost:3000'
   OPENAI_API_KEY: 'sk-fake-ci-key'
 
 jobs:
-  lint-and-typecheck:
-    name: Lint & Typecheck
+  lint-typecheck-build:
+    name: Lint, Typecheck & Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +52,14 @@ jobs:
 
       - name: Typecheck
         run: npx tsc --noEmit
+
+      - name: Initialize database
+        run: |
+          mkdir -p prisma/data
+          yarn db:push
+
+      - name: Build
+        run: yarn build
 
   test:
     name: E2E Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,12 +68,20 @@ When working through Linear tickets:
 3. In the worktree, run `yarn install --immutable && yarn db:generate` before any work
 4. After changes, verify with `npx tsc --noEmit`
 5. Rebase on latest main, commit, push, create PR via `gh pr create`
-6. Wait for CI (Lint & Typecheck + E2E Tests must pass; Mintlify failure is external — ignore)
-7. Merge with `gh pr merge N --squash --delete-branch`
+6. Wait for CI (Lint, Typecheck & Build + E2E Tests must pass; Mintlify failure is external — ignore)
+7. Enqueue PR in merge queue: `gh pr merge N --squash --delete-branch --auto`
 8. Clean up: `git worktree remove ../openfinance-nan-XXX --force`
 9. Update Linear ticket to "Done"
 
 Multiple tickets can run in parallel using separate worktrees. When branches touch the same file, merge the first PR then rebase the second.
+
+### Merge Rules
+
+- **NEVER merge PRs directly** — all PRs go through the merge queue via `--auto`
+- **NEVER use `gh pr merge` without `--auto`** — direct merges bypass the merge queue and can break main
+- The merge queue runs CI checks against the PR rebased on the latest main, ensuring no broken code lands
+- If CI fails in the merge queue, the PR is automatically dequeued — fix the issue, push again, and re-enqueue
+- Use `gh pr merge N --squash --delete-branch --auto` to enqueue (this is the ONLY approved merge command)
 
 ## Critical Rules
 


### PR DESCRIPTION
## Summary
- Add `merge_group` trigger to CI workflow so GitHub merge queue runs CI before merging
- Add `yarn build` step to the lint-typecheck job to catch build failures early (without waiting for E2E)
- Upgrade CI Node.js from 20 to 22
- Add merge queue rules to CLAUDE.md preventing agents from direct-merging to main

## Manual setup needed
After merging this PR, configure in GitHub Settings → Branches:
- **Branch protection rule for `main`**: require `Lint, Typecheck & Build` and `E2E Tests` status checks to pass
- **Require branches to be up to date** before merging
- **Enable merge queue** with squash merge method

Resolves NAN-445

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] After merge, configure branch protection and verify merge queue works

🤖 Generated with [Claude Code](https://claude.com/claude-code)