### PR TITLE
fix: sidebar toggle button now properly collapses conversations panel

### DIFF
--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -640,7 +640,7 @@ export function ChatInterface({ threadId: initialThreadId, initialMessages = [],
         <div className="flex items-center justify-between border-b border-gray-200 px-4 py-2">
           <button
             type="button"
-            onClick={() => setSidebarOpen(true)}
+            onClick={() => setSidebarOpen(prev => !prev)}
             className="inline-flex items-center justify-center rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
             title="View conversations"
           >


### PR DESCRIPTION
## Summary
- Fixed sidebar toggle button that could only open but never close the conversations panel
- Root cause: `onClick` was hardcoded to `setSidebarOpen(true)` instead of toggling
- Changed to `setSidebarOpen(prev => !prev)` — one-line fix

Closes NAN-444

## Test plan
- [ ] Open chat page — conversations panel visible
- [ ] Click toggle button — panel collapses
- [ ] Click again — panel reopens
- [ ] Verify mobile sheet behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)