### PR TITLE
feat: add account deletion flow

### DIFF
--- a/src/app/(private)/settings/page.tsx
+++ b/src/app/(private)/settings/page.tsx
@@ -7,6 +7,7 @@ import { ConnectedBanks } from '@/components/settings/connected-banks'
 import { PlaidKeysForm } from '@/components/settings/plaid-keys-form'
 import { GoogleDriveConnection } from '@/components/settings/google-drive-connection'
 import { ExpenseCategories } from '@/components/settings/expense-categories'
+import { DeleteAccount } from '@/components/settings/delete-account'
 import { getPlaidCredentials } from '@/lib/plaid'
 
 export default async function SettingsPage() {
@@ -72,6 +73,8 @@ export default async function SettingsPage() {
           plaidSecret={settings.plaidSecret}
           plaidEnvironment={settings.plaidEnvironment}
         />
+
+        <DeleteAccount />
       </div>
     </div>
   )

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -1,0 +1,77 @@
+import path from 'path'
+import { rm } from 'fs/promises'
+
+import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export async function DELETE() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId = session.user.id
+
+  try {
+    // Step 1: Delete uploaded files from disk before removing DB records
+    // (we need the userId to locate the directory)
+    const uploadsDir = path.join(process.cwd(), 'data', 'uploads', userId)
+    await rm(uploadsDir, { recursive: true, force: true })
+
+    // Step 2: Delete all database records in a transaction
+    // Most relations cascade from User, so deleting the User record
+    // handles the bulk of cleanup. We delete explicitly where cascade
+    // might not reach or to be explicit about ordering.
+    await prisma.$transaction(async (tx) => {
+      // Delete records that may not cascade directly from User
+      await tx.processingLog.deleteMany({
+        where: { job: { userId } },
+      })
+      await tx.jobItem.deleteMany({
+        where: { job: { userId } },
+      })
+      await tx.balanceVerification.deleteMany({
+        where: { statement: { userId } },
+      })
+      await tx.chatMessage.deleteMany({
+        where: { thread: { userId } },
+      })
+
+      // Delete all direct user-owned records
+      await tx.chatTrace.deleteMany({ where: { userId } })
+      await tx.chatThread.deleteMany({ where: { userId } })
+      await tx.scenario.deleteMany({ where: { userId } })
+      await tx.netWorthSnapshot.deleteMany({ where: { userId } })
+      await tx.netWorthAccount.deleteMany({ where: { userId } })
+      await tx.expenseCategory.deleteMany({ where: { userId } })
+      await tx.document.deleteMany({ where: { userId } })
+      await tx.job.deleteMany({ where: { userId } })
+      await tx.processingJob.deleteMany({ where: { userId } })
+      await tx.userMemory.deleteMany({ where: { userId } })
+      await tx.transaction.deleteMany({ where: { userId } })
+      await tx.bankStatement.deleteMany({ where: { userId } })
+      await tx.bankAccount.deleteMany({ where: { userId } })
+      await tx.plaidConnection.deleteMany({ where: { userId } })
+      await tx.googleDriveConnection.deleteMany({ where: { userId } })
+      await tx.userSettings.deleteMany({ where: { userId } })
+
+      // Delete BetterAuth records
+      await tx.session.deleteMany({ where: { userId } })
+      await tx.account.deleteMany({ where: { userId } })
+
+      // Finally delete the user
+      await tx.user.delete({ where: { id: userId } })
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Account deletion failed:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete account' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/settings/delete-account.tsx
+++ b/src/components/settings/delete-account.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, AlertTriangle } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+export function DeleteAccount() {
+  const [open, setOpen] = useState(false)
+  const [confirmText, setConfirmText] = useState('')
+  const [deleting, setDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isConfirmed = confirmText === 'DELETE'
+
+  async function handleDelete() {
+    if (!isConfirmed) return
+
+    setDeleting(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/account/delete', {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to delete account')
+      }
+
+      // Full page reload to clear session and redirect to landing
+      window.location.href = '/'
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete account')
+      setDeleting(false)
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!deleting) {
+      setOpen(nextOpen)
+      if (!nextOpen) {
+        setConfirmText('')
+        setError(null)
+      }
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 p-6">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-5 w-5 text-red-600" />
+        <h2 className="text-lg font-semibold text-red-900">Danger Zone</h2>
+      </div>
+      <p className="mt-1 text-sm text-red-700">
+        Permanently delete your account and all associated data. This action
+        cannot be undone.
+      </p>
+
+      <div className="mt-4">
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+          <DialogTrigger asChild>
+            <Button variant="destructive">Delete Account</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete Account</DialogTitle>
+              <DialogDescription>
+                This will permanently delete your account and all associated data
+                including transactions, statements, uploaded files, and chat
+                history. This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-2">
+              <div>
+                <label
+                  htmlFor="confirm-delete"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Type <span className="font-mono font-bold">DELETE</span> to
+                  confirm
+                </label>
+                <Input
+                  id="confirm-delete"
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value)}
+                  placeholder="DELETE"
+                  className="mt-1"
+                  disabled={deleting}
+                  autoComplete="off"
+                />
+              </div>
+
+              {error && (
+                <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={!isConfirmed || deleting}
+              >
+                {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
+                {deleting ? 'Deleting...' : 'Delete Account'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add "Danger Zone" section to settings page with account deletion capability
- Create DELETE `/api/account/delete` endpoint that cascades deletion of all user data
- Delete uploaded files from disk before removing database records
- Use Prisma transaction for atomic database cleanup
- Require user to type "DELETE" to confirm, with loading state and error handling

Closes NAN-449

## Test plan
- [ ] Navigate to Settings, verify "Danger Zone" section appears at bottom
- [ ] Click "Delete Account", verify confirmation dialog appears
- [ ] Verify delete button is disabled until "DELETE" is typed
- [ ] Test cancellation closes dialog and resets state
- [ ] Verify successful deletion redirects to landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)