### PR TITLE
feat: encrypt sensitive data at rest with AES-256-GCM

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -316,7 +316,7 @@ model PlaidConnection {
   user            User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   institutionId   String
   institutionName String
-  accessToken     String    // TODO: encrypt at rest
+  accessToken     String    // Encrypted at rest via src/lib/encryption.ts
   itemId          String    @unique
   cursor          String?   // Plaid sync cursor for incremental updates
   status          String    @default("active") // active | error | disconnected

--- a/scripts/encrypt-existing-data.ts
+++ b/scripts/encrypt-existing-data.ts
@@ -1,0 +1,143 @@
+/**
+ * Migration script: encrypt existing plaintext tokens and credentials.
+ *
+ * Reads all PlaidConnections, GoogleDriveConnections, Accounts, and UserSettings,
+ * checks for unencrypted values using the `enc:` prefix, and encrypts them in place.
+ *
+ * Usage:
+ *   ENCRYPTION_KEY=<64-char-hex> npx tsx scripts/encrypt-existing-data.ts
+ *
+ * Safe to run multiple times — already-encrypted values are skipped.
+ */
+
+import { PrismaClient } from '../src/generated/prisma/client'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+
+import { encrypt, isEncrypted } from '../src/lib/encryption'
+
+const adapter = new PrismaBetterSqlite3({
+  url: process.env.DATABASE_URL || 'file:./data/openfinance.db',
+})
+const prisma = new PrismaClient({ adapter })
+
+function encryptIfNeeded(value: string | null): { updated: boolean; value: string | null } {
+  if (!value) return { updated: false, value }
+  if (isEncrypted(value)) return { updated: false, value }
+  return { updated: true, value: encrypt(value) }
+}
+
+async function encryptPlaidConnections() {
+  const connections = await prisma.plaidConnection.findMany()
+  let count = 0
+
+  for (const conn of connections) {
+    const accessToken = encryptIfNeeded(conn.accessToken)
+
+    if (accessToken.updated) {
+      await prisma.plaidConnection.update({
+        where: { id: conn.id },
+        data: { accessToken: accessToken.value! },
+      })
+      count++
+    }
+  }
+
+  console.log(`PlaidConnections: encrypted ${count} of ${connections.length} records`)
+}
+
+async function encryptGoogleDriveConnections() {
+  const connections = await prisma.googleDriveConnection.findMany()
+  let count = 0
+
+  for (const conn of connections) {
+    const accessToken = encryptIfNeeded(conn.accessToken)
+    const refreshToken = encryptIfNeeded(conn.refreshToken)
+
+    if (accessToken.updated || refreshToken.updated) {
+      await prisma.googleDriveConnection.update({
+        where: { id: conn.id },
+        data: {
+          ...(accessToken.updated && { accessToken: accessToken.value! }),
+          ...(refreshToken.updated && { refreshToken: refreshToken.value! }),
+        },
+      })
+      count++
+    }
+  }
+
+  console.log(`GoogleDriveConnections: encrypted ${count} of ${connections.length} records`)
+}
+
+async function encryptAccounts() {
+  const accounts = await prisma.account.findMany()
+  let count = 0
+
+  for (const acct of accounts) {
+    const accessToken = encryptIfNeeded(acct.accessToken)
+    const refreshToken = encryptIfNeeded(acct.refreshToken)
+    const idToken = encryptIfNeeded(acct.idToken)
+
+    if (accessToken.updated || refreshToken.updated || idToken.updated) {
+      await prisma.account.update({
+        where: { id: acct.id },
+        data: {
+          ...(accessToken.updated && { accessToken: accessToken.value }),
+          ...(refreshToken.updated && { refreshToken: refreshToken.value }),
+          ...(idToken.updated && { idToken: idToken.value }),
+        },
+      })
+      count++
+    }
+  }
+
+  console.log(`Accounts (BetterAuth): encrypted ${count} of ${accounts.length} records`)
+}
+
+async function encryptUserSettings() {
+  const allSettings = await prisma.userSettings.findMany()
+  let count = 0
+
+  for (const settings of allSettings) {
+    const plaidClientId = encryptIfNeeded(settings.plaidClientId)
+    const plaidSecret = encryptIfNeeded(settings.plaidSecret)
+
+    if (plaidClientId.updated || plaidSecret.updated) {
+      await prisma.userSettings.update({
+        where: { id: settings.id },
+        data: {
+          ...(plaidClientId.updated && { plaidClientId: plaidClientId.value }),
+          ...(plaidSecret.updated && { plaidSecret: plaidSecret.value }),
+        },
+      })
+      count++
+    }
+  }
+
+  console.log(`UserSettings: encrypted ${count} of ${allSettings.length} records`)
+}
+
+async function main() {
+  if (!process.env.ENCRYPTION_KEY) {
+    console.error('ERROR: ENCRYPTION_KEY environment variable is not set.')
+    console.error('Generate one with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"')
+    process.exit(1)
+  }
+
+  console.log('Encrypting existing data...\n')
+
+  await encryptPlaidConnections()
+  await encryptGoogleDriveConnections()
+  await encryptAccounts()
+  await encryptUserSettings()
+
+  console.log('\nDone. All sensitive data has been encrypted.')
+}
+
+main()
+  .catch((error) => {
+    console.error('Migration failed:', error)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/app/(private)/settings/page.tsx
+++ b/src/app/(private)/settings/page.tsx
@@ -1,14 +1,16 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
+
+import { decrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
+import { getPlaidCredentials } from '@/lib/plaid'
 import { SettingsForm } from '@/components/settings/settings-form'
 import { ConnectedBanks } from '@/components/settings/connected-banks'
 import { PlaidKeysForm } from '@/components/settings/plaid-keys-form'
 import { GoogleDriveConnection } from '@/components/settings/google-drive-connection'
 import { ExpenseCategories } from '@/components/settings/expense-categories'
 import { DeleteAccount } from '@/components/settings/delete-account'
-import { getPlaidCredentials } from '@/lib/plaid'
 
 export default async function SettingsPage() {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -69,8 +71,8 @@ export default async function SettingsPage() {
         <GoogleDriveConnection googleConfigured={googleConfigured} />
 
         <PlaidKeysForm
-          plaidClientId={settings.plaidClientId}
-          plaidSecret={settings.plaidSecret}
+          plaidClientId={settings.plaidClientId ? decrypt(settings.plaidClientId) : null}
+          plaidSecret={settings.plaidSecret ? decrypt(settings.plaidSecret) : null}
           plaidEnvironment={settings.plaidEnvironment}
         />
 

--- a/src/app/api/drive/callback/route.ts
+++ b/src/app/api/drive/callback/route.ts
@@ -1,6 +1,8 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
+
+import { encrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 import { exchangeCodeForTokens, getGoogleEmail } from '@/lib/services/google-drive'
 
@@ -39,19 +41,19 @@ export async function GET(request: NextRequest) {
     // Get the email associated with this Google account
     const email = await getGoogleEmail(tokens.access_token)
 
-    // Upsert the connection
+    // Upsert the connection with encrypted tokens
     await prisma.googleDriveConnection.upsert({
       where: { userId: session.user.id },
       create: {
         userId: session.user.id,
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
+        accessToken: encrypt(tokens.access_token),
+        refreshToken: encrypt(tokens.refresh_token),
         expiresAt,
         email,
       },
       update: {
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
+        accessToken: encrypt(tokens.access_token),
+        refreshToken: encrypt(tokens.refresh_token),
         expiresAt,
         email,
       },

--- a/src/app/api/drive/import/route.ts
+++ b/src/app/api/drive/import/route.ts
@@ -2,6 +2,8 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 import { writeFile } from 'fs/promises'
+
+import { decrypt, encrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 import { prepareUpload } from '@/lib/upload-path'
 import { downloadDriveFile, refreshAccessToken } from '@/lib/services/google-drive'
@@ -48,9 +50,9 @@ export async function POST(request: NextRequest) {
 
   try {
     // Refresh access token if expired
-    let accessToken = connection.accessToken
+    let accessToken = decrypt(connection.accessToken)
     if (new Date() >= connection.expiresAt) {
-      const credentials = await refreshAccessToken(connection.refreshToken)
+      const credentials = await refreshAccessToken(decrypt(connection.refreshToken))
       if (!credentials.access_token) {
         throw new Error('Failed to refresh access token')
       }
@@ -59,7 +61,7 @@ export async function POST(request: NextRequest) {
       await prisma.googleDriveConnection.update({
         where: { userId: session.user.id },
         data: {
-          accessToken: credentials.access_token,
+          accessToken: encrypt(credentials.access_token),
           expiresAt: credentials.expiry_date
             ? new Date(credentials.expiry_date)
             : new Date(Date.now() + 3600 * 1000),

--- a/src/app/api/plaid/connections/[id]/route.ts
+++ b/src/app/api/plaid/connections/[id]/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
+import { decrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 import { getPlaidClientForUser } from '@/lib/plaid'
 
@@ -28,7 +29,7 @@ export async function DELETE(
   try {
     const client = await getPlaidClientForUser(session.user.id)
     if (client) {
-      await client.itemRemove({ access_token: connection.accessToken })
+      await client.itemRemove({ access_token: decrypt(connection.accessToken) })
     }
   } catch (error) {
     // If removal from Plaid fails, still disconnect locally

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
+import { encrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 import { getPlaidClientForUser } from '@/lib/plaid'
 import { syncPlaidTransactions } from '@/lib/services/plaid-sync'
@@ -34,11 +35,11 @@ export async function POST(request: NextRequest) {
 
     const { access_token, item_id } = exchangeResponse.data
 
-    // Store the connection
+    // Store the connection with encrypted access token
     const connection = await prisma.plaidConnection.create({
       data: {
         userId: session.user.id,
-        accessToken: access_token,
+        accessToken: encrypt(access_token),
         itemId: item_id,
         institutionId: institution?.institution_id || 'unknown',
         institutionName: institution?.name || 'Unknown Institution',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import { betterAuth } from 'better-auth'
 import { prismaAdapter } from 'better-auth/adapters/prisma'
 import { nextCookies } from 'better-auth/next-js'
 
+import { encrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 
 const googleClientId = process.env.GOOGLE_CLIENT_ID
@@ -38,6 +39,41 @@ export const auth = betterAuth({
     cookieCache: {
       enabled: true,
       maxAge: 300,
+    },
+  },
+
+  databaseHooks: {
+    account: {
+      create: {
+        async before(account) {
+          const encrypted = { ...account }
+          if (encrypted.accessToken) {
+            encrypted.accessToken = encrypt(encrypted.accessToken)
+          }
+          if (encrypted.refreshToken) {
+            encrypted.refreshToken = encrypt(encrypted.refreshToken)
+          }
+          if (encrypted.idToken) {
+            encrypted.idToken = encrypt(encrypted.idToken)
+          }
+          return { data: encrypted }
+        },
+      },
+      update: {
+        async before(account) {
+          const encrypted = { ...account }
+          if (encrypted.accessToken) {
+            encrypted.accessToken = encrypt(encrypted.accessToken)
+          }
+          if (encrypted.refreshToken) {
+            encrypted.refreshToken = encrypt(encrypted.refreshToken)
+          }
+          if (encrypted.idToken) {
+            encrypted.idToken = encrypt(encrypted.idToken)
+          }
+          return { data: encrypted }
+        },
+      },
     },
   },
 

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -1,0 +1,103 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 12
+const AUTH_TAG_LENGTH = 16
+const ENCRYPTED_PREFIX = 'enc:'
+
+let encryptionKey: Buffer | null = null
+let warnedNoKey = false
+
+function getKey(): Buffer | null {
+  if (encryptionKey) return encryptionKey
+
+  const hex = process.env.ENCRYPTION_KEY
+  if (!hex) {
+    if (!warnedNoKey) {
+      console.warn(
+        '[encryption] ENCRYPTION_KEY not set — encryption is disabled. '
+        + 'Data will be stored in plaintext. '
+        + 'Set ENCRYPTION_KEY to a 64-character hex string (32 bytes) to enable encryption.',
+      )
+      warnedNoKey = true
+    }
+    return null
+  }
+
+  if (hex.length !== 64 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error(
+      'ENCRYPTION_KEY must be a 64-character hex string (32 bytes). '
+      + `Got ${hex.length} characters.`,
+    )
+  }
+
+  encryptionKey = Buffer.from(hex, 'hex')
+  return encryptionKey
+}
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM.
+ * Returns: `enc:` prefix + base64(IV + authTag + ciphertext)
+ *
+ * If ENCRYPTION_KEY is not set, returns plaintext as-is (pass-through mode).
+ */
+export function encrypt(plaintext: string): string {
+  const key = getKey()
+  if (!key) return plaintext
+
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ])
+
+  const authTag = cipher.getAuthTag()
+
+  // Format: IV (12 bytes) + authTag (16 bytes) + ciphertext
+  const combined = Buffer.concat([iv, authTag, encrypted])
+
+  return ENCRYPTED_PREFIX + combined.toString('base64')
+}
+
+/**
+ * Decrypt an encrypted string produced by encrypt().
+ * Handles both encrypted values (with `enc:` prefix) and plaintext (backwards-compatible).
+ *
+ * If ENCRYPTION_KEY is not set, returns the value as-is.
+ */
+export function decrypt(encrypted: string): string {
+  if (!isEncrypted(encrypted)) return encrypted
+
+  const key = getKey()
+  if (!key) {
+    // Key not set but value looks encrypted — strip prefix and return as-is
+    // This shouldn't happen in production but prevents crashes during development
+    return encrypted
+  }
+
+  const combined = Buffer.from(encrypted.slice(ENCRYPTED_PREFIX.length), 'base64')
+
+  const iv = combined.subarray(0, IV_LENGTH)
+  const authTag = combined.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH)
+  const ciphertext = combined.subarray(IV_LENGTH + AUTH_TAG_LENGTH)
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(authTag)
+
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ])
+
+  return decrypted.toString('utf8')
+}
+
+/**
+ * Check if a value is already encrypted (starts with the `enc:` prefix).
+ * Useful for detecting pre-migration plaintext values.
+ */
+export function isEncrypted(value: string): boolean {
+  return value.startsWith(ENCRYPTED_PREFIX)
+}

--- a/src/lib/plaid.ts
+++ b/src/lib/plaid.ts
@@ -1,5 +1,6 @@
 import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid'
 
+import { decrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 
 type PlaidEnvironmentName = 'sandbox' | 'development' | 'production'
@@ -43,8 +44,8 @@ export async function getPlaidCredentials(
   // Self-hosted: user provides their own keys
   if (settings?.plaidClientId && settings?.plaidSecret) {
     return {
-      clientId: settings.plaidClientId,
-      secret: settings.plaidSecret,
+      clientId: decrypt(settings.plaidClientId),
+      secret: decrypt(settings.plaidSecret),
       environment: (settings.plaidEnvironment || 'sandbox') as PlaidEnvironmentName,
     }
   }

--- a/src/lib/services/plaid-sync.ts
+++ b/src/lib/services/plaid-sync.ts
@@ -1,5 +1,6 @@
 import { PlaidApi, Transaction as PlaidTransaction, RemovedTransaction } from 'plaid'
 
+import { decrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 
 interface SyncResult {
@@ -29,6 +30,7 @@ export async function syncPlaidTransactions(
     throw new Error('Unauthorized')
   }
 
+  const accessToken = decrypt(connection.accessToken)
   let cursor = connection.cursor
   const allAdded: PlaidTransaction[] = []
   const allModified: PlaidTransaction[] = []
@@ -38,7 +40,7 @@ export async function syncPlaidTransactions(
   try {
     while (hasMore) {
       const response = await client.transactionsSync({
-        access_token: connection.accessToken,
+        access_token: accessToken,
         cursor: cursor ?? undefined,
       })
 


### PR DESCRIPTION
## Summary
- Add AES-256-GCM encryption for sensitive data at rest via `ENCRYPTION_KEY` env var
- Encrypt Plaid access tokens, Google Drive OAuth tokens, BetterAuth OAuth tokens, and user Plaid API credentials
- Transparent encrypt-on-write / decrypt-on-read — no schema changes needed
- Graceful pass-through when `ENCRYPTION_KEY` is not set (development mode)
- Include `scripts/encrypt-existing-data.ts` migration script for encrypting pre-existing data
- Use `enc:` prefix format for backwards compatibility with unencrypted values

Closes NAN-450

## Test plan
- [ ] Verify app works without `ENCRYPTION_KEY` set (pass-through mode)
- [ ] Set `ENCRYPTION_KEY` (64-char hex), verify Plaid credentials save/load correctly
- [ ] Verify Google Drive connection flow works with encryption
- [ ] Run `encrypt-existing-data.ts` script and verify idempotency
- [ ] Verify encrypted values in DB start with `enc:` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)