### PR TITLE
feat: add better AI models and smarter default

### DIFF
--- a/prisma/migrations/20260222044340_update_default_ai_model/migration.sql
+++ b/prisma/migrations/20260222044340_update_default_ai_model/migration.sql
@@ -1,0 +1,25 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_UserSettings" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "fiscalYearEndMonth" INTEGER NOT NULL DEFAULT 12,
+    "fiscalYearEndDay" INTEGER NOT NULL DEFAULT 31,
+    "bankTimezone" TEXT NOT NULL DEFAULT 'America/Vancouver',
+    "userTimezone" TEXT NOT NULL DEFAULT 'America/Vancouver',
+    "aiContext" TEXT,
+    "aiModel" TEXT NOT NULL DEFAULT 'openrouter/cerebras/zai-glm-4.7',
+    "plaidClientId" TEXT,
+    "plaidSecret" TEXT,
+    "plaidEnvironment" TEXT NOT NULL DEFAULT 'sandbox',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UserSettings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_UserSettings" ("aiContext", "aiModel", "bankTimezone", "createdAt", "fiscalYearEndDay", "fiscalYearEndMonth", "id", "plaidClientId", "plaidEnvironment", "plaidSecret", "updatedAt", "userId", "userTimezone") SELECT "aiContext", "aiModel", "bankTimezone", "createdAt", "fiscalYearEndDay", "fiscalYearEndMonth", "id", "plaidClientId", "plaidEnvironment", "plaidSecret", "updatedAt", "userId", "userTimezone" FROM "UserSettings";
+DROP TABLE "UserSettings";
+ALTER TABLE "new_UserSettings" RENAME TO "UserSettings";
+CREATE UNIQUE INDEX "UserSettings_userId_key" ON "UserSettings"("userId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,7 +99,7 @@ model UserSettings {
   bankTimezone       String   @default("America/Vancouver")
   userTimezone       String   @default("America/Vancouver")
   aiContext          String?
-  aiModel            String   @default("openai/gpt-4o-mini")
+  aiModel            String   @default("openrouter/cerebras/zai-glm-4.7")
   plaidClientId      String?  // Self-hosted: user's own Plaid client ID
   plaidSecret        String?  // Self-hosted: user's own Plaid secret
   plaidEnvironment   String   @default("sandbox") // sandbox | development | production

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -60,7 +60,7 @@ const handler = async (request: Request) => {
     where: { userId: session.user.id },
   })
 
-  const modelId = settings?.aiModel ?? 'openrouter/cerebras/auto'
+  const modelId = settings?.aiModel ?? 'openrouter/cerebras/zai-glm-4.7'
 
   const isNewUser = !settings?.aiContext
   const memories = await loadMemoriesForPrompt(session.user.id)

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -215,10 +215,13 @@ export function SettingsForm({ settings: initial, accounts: initialAccounts }: S
               className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm"
             >
               <optgroup label="OpenRouter">
-                <option value="openrouter/cerebras/auto">Cerebras Auto (fastest)</option>
+                <option value="openrouter/cerebras/zai-glm-4.7">GLM 4.7 via Cerebras (fastest)</option>
+                <option value="openrouter/z-ai/glm-5">GLM 5 (flagship, 744B)</option>
+                <option value="openrouter/anthropic/claude-sonnet-4-5">Claude Sonnet 4.5</option>
+                <option value="openrouter/google/gemini-2.5-pro-preview">Gemini 2.5 Pro</option>
                 <option value="openrouter/google/gemini-2.5-flash-preview">Gemini 2.5 Flash</option>
               </optgroup>
-              <optgroup label="OpenAI">
+              <optgroup label="OpenAI (Direct)">
                 <option value="openai/gpt-4o-mini">GPT-4o Mini</option>
                 <option value="openai/gpt-4o">GPT-4o</option>
               </optgroup>

--- a/src/lib/chat/system-prompt.ts
+++ b/src/lib/chat/system-prompt.ts
@@ -26,7 +26,7 @@ Today is ${today}. Use this to interpret relative date references like "last mon
 - **get_cashflow**: Get cashflow data for a date range
 - **get_category_breakdown**: Get spending breakdown by category
 - **get_settings**: Read the user's current settings (fiscal year, timezone, AI model, personal context)
-- **update_settings**: Update user settings — fiscal year end (month 1-12, day 1-31), timezones (IANA format), AI model ("openai/gpt-4o-mini" or "openai/gpt-4o"), personal context
+- **update_settings**: Update user settings — fiscal year end (month 1-12, day 1-31), timezones (IANA format), AI model (e.g. "openrouter/cerebras/zai-glm-4.7", "openrouter/z-ai/glm-5", "openrouter/anthropic/claude-sonnet-4-5", "openrouter/google/gemini-2.5-pro-preview", "openrouter/google/gemini-2.5-flash-preview", "openai/gpt-4o-mini", "openai/gpt-4o"), personal context
 - **calculate_tax**: Calculate Canadian federal income tax brackets and rates for a given income
 - **calculate_compound_growth**: Project investment growth with compound interest over time
 - **calculate_rrsp**: Get RRSP contribution room and estimated tax refund for an income level


### PR DESCRIPTION
## Summary
- Change default model from `cerebras/auto` to `cerebras/zai-glm-4.7` (faster + smarter)
- Add new models to settings selector: Claude Sonnet 4.5, GLM 5 (744B), Gemini 2.5 Pro
- Update system prompt to reflect available model options
- Update Prisma schema default for new users

Closes NAN-454

## Test plan
- [ ] Verify new users get GLM 4.7 as default
- [ ] Open Settings, verify expanded model dropdown
- [ ] Select each model and save, verify chat works
- [ ] Ask AI to change model via chat, verify it knows the options

🤖 Generated with [Claude Code](https://claude.com/claude-code)