### PR TITLE
feat: add shareable conversation URLs

### DIFF
--- a/src/app/(private)/chat/[threadId]/page.tsx
+++ b/src/app/(private)/chat/[threadId]/page.tsx
@@ -1,0 +1,61 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import { ChatInterface } from '@/components/chat/chat-interface'
+
+interface ChatThreadPageProps {
+  params: Promise<{ threadId: string }>
+}
+
+export default async function ChatThreadPage({ params }: ChatThreadPageProps) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) redirect('/auth/login')
+
+  const { threadId } = await params
+
+  const thread = await prisma.chatThread.findFirst({
+    where: { id: threadId, userId: session.user.id },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!thread) redirect('/chat')
+
+  const initialMessages = thread.messages.map(m => ({
+    id: m.id,
+    role: m.role as 'user' | 'assistant',
+    parts: [{ type: 'text' as const, text: m.content }],
+  }))
+
+  const initialTraceIds: Record<string, string> = {}
+  for (const m of thread.messages) {
+    if (m.traceId) {
+      initialTraceIds[m.id] = m.traceId
+    }
+  }
+
+  // Check if user needs onboarding (no personal context set and no previous messages)
+  const settings = await prisma.userSettings.findUnique({
+    where: { userId: session.user.id },
+  })
+
+  const totalMessages = await prisma.chatMessage.count({
+    where: { thread: { userId: session.user.id } },
+  })
+
+  const isNewUser = !settings?.aiContext && totalMessages === 0
+
+  return (
+    <ChatInterface
+      key={thread.id}
+      threadId={thread.id}
+      initialMessages={initialMessages}
+      initialTraceIds={initialTraceIds}
+      isNewUser={isNewUser}
+    />
+  )
+}

--- a/src/app/(private)/chat/page.tsx
+++ b/src/app/(private)/chat/page.tsx
@@ -2,7 +2,6 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
-import { ChatInterface } from '@/components/chat/chat-interface'
 
 export default async function ChatPage() {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -11,54 +10,13 @@ export default async function ChatPage() {
   let thread = await prisma.chatThread.findFirst({
     where: { userId: session.user.id, isArchived: false },
     orderBy: { updatedAt: 'desc' },
-    include: {
-      messages: {
-        orderBy: { createdAt: 'asc' },
-      },
-    },
   })
 
   if (!thread) {
     thread = await prisma.chatThread.create({
       data: { userId: session.user.id },
-      include: {
-        messages: {
-          orderBy: { createdAt: 'asc' },
-        },
-      },
     })
   }
 
-  const initialMessages = thread.messages.map(m => ({
-    id: m.id,
-    role: m.role as 'user' | 'assistant',
-    parts: [{ type: 'text' as const, text: m.content }],
-  }))
-
-  const initialTraceIds: Record<string, string> = {}
-  for (const m of thread.messages) {
-    if (m.traceId) {
-      initialTraceIds[m.id] = m.traceId
-    }
-  }
-
-  // Check if user needs onboarding (no personal context set and no previous messages)
-  const settings = await prisma.userSettings.findUnique({
-    where: { userId: session.user.id },
-  })
-
-  const totalMessages = await prisma.chatMessage.count({
-    where: { thread: { userId: session.user.id } },
-  })
-
-  const isNewUser = !settings?.aiContext && totalMessages === 0
-
-  return (
-    <ChatInterface
-      threadId={thread.id}
-      initialMessages={initialMessages}
-      initialTraceIds={initialTraceIds}
-      isNewUser={isNewUser}
-    />
-  )
+  redirect(`/chat/${thread.id}`)
 }


### PR DESCRIPTION
## Summary
- Each chat thread is now accessible at `/chat/{threadId}` with a unique permalink
- `/chat` redirects to the latest active thread (or creates a new one)
- Thread switching uses URL-based navigation instead of client-side state
- Add "Copy link" button to chat header for sharing conversation URLs
- Component remounts cleanly via React `key` prop on thread change

Closes NAN-453

## Test plan
- [ ] Visit `/chat`, verify redirect to `/chat/{threadId}`
- [ ] Click threads in sidebar, verify URL updates
- [ ] Click "Copy link" button, verify URL copied to clipboard
- [ ] Navigate directly to `/chat/{threadId}` with a valid ID
- [ ] Navigate to invalid thread ID, verify redirect to `/chat`
- [ ] Create new chat, verify new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)