### PR TITLE
feat: add "Process as Statement" action for PDF documents

### DIFF
--- a/src/app/api/documents/process-as-statement/route.ts
+++ b/src/app/api/documents/process-as-statement/route.ts
@@ -1,0 +1,81 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { readFile } from 'fs/promises'
+import { getUploadFullPath } from '@/lib/upload-path'
+import { processStatement } from '@/lib/services/statement-processor'
+import { prisma } from '@/lib/prisma'
+
+// pdf-parse v1 has no proper ESM/TS types — use require
+const pdfParse = require('pdf-parse')
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { documentId } = body
+
+  if (!documentId) {
+    return NextResponse.json({ error: 'Missing documentId' }, { status: 400 })
+  }
+
+  // Look up the Document record
+  const document = await prisma.document.findUnique({
+    where: { id: documentId },
+  })
+
+  if (!document || document.userId !== session.user.id) {
+    return NextResponse.json({ error: 'Document not found' }, { status: 404 })
+  }
+
+  if (document.mimeType !== 'application/pdf') {
+    return NextResponse.json({ error: 'Only PDF documents can be processed as statements' }, { status: 400 })
+  }
+
+  try {
+    // Read the PDF file
+    const fullPath = getUploadFullPath(document.fileUrl)
+    const pdfBuffer = await readFile(fullPath)
+
+    // Extract text
+    const pdfData = await pdfParse(pdfBuffer)
+    const pdfText: string = pdfData.text
+
+    if (!pdfText || pdfText.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Could not extract text from PDF. The file may be scanned/image-based.' },
+        { status: 422 },
+      )
+    }
+
+    // Process with AI (creates BankStatement + Transactions)
+    const result = await processStatement(
+      pdfText,
+      document.fileName,
+      document.fileUrl,
+      document.fileSize,
+      session.user.id,
+    )
+
+    return NextResponse.json({
+      success: true,
+      data: result,
+      message: result.message,
+    })
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to process statement'
+
+    if (error instanceof Error && error.message.includes('Duplicate statement detected')) {
+      return NextResponse.json(
+        { success: false, isDuplicate: true, message: error.message },
+        { status: 409 },
+      )
+    }
+
+    console.error('Process document as statement error:', error)
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- PDF documents classified as "statement" now show a **Process as Statement** option in their context menu
- New API route `/api/documents/process-as-statement` looks up the Document, reads the PDF, extracts text, and runs the full statement processing pipeline
- Handles duplicate detection (409), loading states, and toast notifications

Closes NAN-456

## Test plan
- [ ] Upload a PDF to the Documents page
- [ ] Verify "Process as Statement" appears in the context menu for PDFs classified as `statement`
- [ ] Click it and verify transactions are extracted
- [ ] Try processing the same document again — should show duplicate warning
- [ ] Verify non-PDF documents don't show the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)