### PR TITLE
feat: add onboarding guides directing users to Statements page

### DIFF
--- a/src/app/(private)/dashboard/page.tsx
+++ b/src/app/(private)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { headers } from 'next/headers'
 import { subMonths, format } from 'date-fns'
 import { ArrowDownRight, ArrowUpRight, TrendingUp } from 'lucide-react'
+import Link from 'next/link'
 
 import { auth } from '@/lib/auth'
 import {
@@ -25,7 +26,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
   const params = await searchParams
   const ownershipFilter: OwnershipFilterType = params.ownership ?? 'combined'
 
-  const { stats, cashflowData } = await getDashboard(
+  const { stats, cashflowData, totalTransactions } = await getDashboard(
     session.user.id,
     ownershipFilter,
   )
@@ -85,6 +86,21 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
         </div>
         <OwnershipFilter value={ownershipFilter} />
       </div>
+
+      {totalTransactions === 0 && (
+        <div className="mb-8 rounded-lg border border-gray-200 bg-white p-10 text-center">
+          <h2 className="text-lg font-semibold text-gray-900">No transactions yet</h2>
+          <p className="mt-2 text-sm text-gray-500">
+            Upload a bank statement to automatically extract and categorize your transactions.
+          </p>
+          <Link
+            href="/statements"
+            className="mt-6 inline-block rounded-md bg-gray-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-gray-700"
+          >
+            Go to Statements
+          </Link>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {statsCards.map((stat, index) => {

--- a/src/app/(private)/documents/page.tsx
+++ b/src/app/(private)/documents/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
+import Link from 'next/link'
 
 import { DocumentFilters } from '@/components/documents/document-filters'
 import { DocumentTable } from '@/components/documents/document-table'
@@ -123,6 +124,14 @@ export default async function DocumentsPage({ searchParams }: DocumentsPageProps
         <div className="flex items-center gap-2">
           <DriveImportSheet />
         </div>
+      </div>
+
+      <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+        To extract transactions from bank statements, use the{' '}
+        <Link href="/statements" className="font-medium underline underline-offset-2 hover:text-blue-900">
+          Statements page
+        </Link>
+        . Documents stored here are for reference only.
       </div>
 
       <DocumentUploader />

--- a/src/lib/chat/system-prompt.ts
+++ b/src/lib/chat/system-prompt.ts
@@ -129,7 +129,7 @@ This is a new user who just signed up. Start a friendly onboarding conversation 
    - Any specific financial concerns or questions?
 3. As they answer, use the **update_settings** tool to save their responses as personal context (aiContext field)
 4. After gathering context, suggest next steps:
-   - Upload their first bank statement
+   - Upload their first bank statement via the **Statements** page (not the Documents page — Documents is for reference files only; the Statements page processes PDFs and extracts transactions automatically)
    - Ask any financial questions
 5. Keep the tone conversational and encouraging — this is a chat, not a form
 6. Save all gathered information to aiContext in one go after the conversation using update_settings` : ''

--- a/src/lib/services/dashboard-types.ts
+++ b/src/lib/services/dashboard-types.ts
@@ -19,6 +19,7 @@ export interface CashflowDataPoint {
 export interface DashboardData {
   stats: DashboardStats
   cashflowData: CashflowDataPoint[]
+  totalTransactions: number
 }
 
 export function formatCurrency(amount: number, currency = 'CAD'): string {

--- a/src/lib/services/dashboard.ts
+++ b/src/lib/services/dashboard.ts
@@ -100,9 +100,12 @@ export async function getDashboard(
     changeExpensesPercent: calculatePercentChange(monthlyExpenses, prevMonthExpenses),
   }
 
-  const cashflowData = await getCashflowData(userId, ownershipFilter)
+  const [cashflowData, totalTransactions] = await Promise.all([
+    getCashflowData(userId, ownershipFilter),
+    prisma.transaction.count({ where: { userId } }),
+  ])
 
-  return { stats, cashflowData }
+  return { stats, cashflowData, totalTransactions }
 }
 
 async function getCashflowData(


### PR DESCRIPTION
## Summary
- **Dashboard**: empty state card when no transactions exist — "Upload your first bank statement" with CTA linking to `/statements`
- **Documents page**: info banner clarifying that Documents is for reference, Statements page is for extraction
- **Chat onboarding**: system prompt now explicitly mentions the Statements page (not Documents) for processing bank statements

Closes NAN-459

## Test plan
- [ ] New user sees empty state card on dashboard with link to Statements
- [ ] Documents page shows info banner about Statements page
- [ ] Chat onboarding mentions the Statements page for uploading bank statements
- [ ] After uploading a statement and getting transactions, dashboard card disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)