### PR TITLE
fix: wire document upload to trigger statement processing pipeline

### DIFF
--- a/src/app/(private)/documents/page.tsx
+++ b/src/app/(private)/documents/page.tsx
@@ -2,8 +2,6 @@ import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
-import Link from 'next/link'
-
 import { DocumentFilters } from '@/components/documents/document-filters'
 import { DocumentTable } from '@/components/documents/document-table'
 import { DocumentUploader } from '@/components/documents/document-uploader'
@@ -124,14 +122,6 @@ export default async function DocumentsPage({ searchParams }: DocumentsPageProps
         <div className="flex items-center gap-2">
           <DriveImportSheet />
         </div>
-      </div>
-
-      <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
-        To extract transactions from bank statements, use the{' '}
-        <Link href="/statements" className="font-medium underline underline-offset-2 hover:text-blue-900">
-          Statements page
-        </Link>
-        . Documents stored here are for reference only.
       </div>
 
       <DocumentUploader />

--- a/src/lib/services/document-classifier.ts
+++ b/src/lib/services/document-classifier.ts
@@ -13,6 +13,11 @@ const STATEMENT_PATTERNS: RegExp[] = [
   /\bbank\b.*\d{4}/i,
   /\baccount\b.*\d{4}/i,
   /\bacct\b.*\d{4}/i,
+  /\bchequ(e|ing)\b/i,
+  /\bsavings?\b/i,
+  /\bcredit.?card\b/i,
+  /\bvisa\b.*\d{4}/i,
+  /\bmastercard\b/i,
 ]
 
 const TAX_PATTERNS: RegExp[] = [


### PR DESCRIPTION
## Summary
- Fixes the #1 blocker: uploading documents via the Documents page now actually triggers AI statement processing
- When a PDF is classified as "statement", the upload route creates a BankStatement record and the frontend triggers processing
- Removes misleading "use Statements page" banner
- Improves document classifier with patterns for chequing/savings/credit card filenames

Fixes NAN-462, NAN-463

## Test plan
- [ ] Upload a single bank statement PDF → verify transactions are extracted
- [ ] Upload multiple PDFs → verify bulk processing runs and all statements get transactions
- [ ] Upload a non-statement PDF → verify no BankStatement record is created
- [ ] Check Statements page shows processed statements with transaction counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)