### PR TITLE
fix: dashboard and expenses show $0 due to category filtering

### DIFF
--- a/src/app/api/expenses/breakdown/route.ts
+++ b/src/app/api/expenses/breakdown/route.ts
@@ -77,7 +77,7 @@ function getDateRange(
   }
 }
 
-const EXPENSE_CATEGORIES = ['expense', 'owner-pay']
+const DEBIT_TYPE = 'debit'
 
 export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -195,7 +195,7 @@ export async function GET(request: NextRequest) {
       by: ['category'],
       where: {
         userId,
-        category: { in: EXPENSE_CATEGORIES },
+        transactionType: DEBIT_TYPE,
         transactionDate: { gte: start, lte: end },
       },
       _sum: { amount: true },
@@ -205,7 +205,7 @@ export async function GET(request: NextRequest) {
       by: ['category'],
       where: {
         userId,
-        category: { in: EXPENSE_CATEGORIES },
+        transactionType: DEBIT_TYPE,
         transactionDate: { gte: prevStart, lte: prevEnd },
       },
       _sum: { amount: true },
@@ -223,7 +223,7 @@ export async function GET(request: NextRequest) {
     by: ['category', 'description'],
     where: {
       userId,
-      category: { in: EXPENSE_CATEGORIES },
+      transactionType: DEBIT_TYPE,
       transactionDate: { gte: start, lte: end },
     },
     _sum: { amount: true },

--- a/src/lib/services/dashboard.ts
+++ b/src/lib/services/dashboard.ts
@@ -39,7 +39,7 @@ export async function getDashboard(
       prisma.transaction.aggregate({
         where: {
           userId,
-          category: 'income',
+          transactionType: 'credit',
           transactionDate: {
             gte: startOfMonth(lastMonth),
             lte: endOfMonth(lastMonth),
@@ -51,7 +51,7 @@ export async function getDashboard(
       prisma.transaction.aggregate({
         where: {
           userId,
-          category: { in: ['expense', 'owner-pay'] },
+          transactionType: 'debit',
           transactionDate: {
             gte: startOfMonth(lastMonth),
             lte: endOfMonth(lastMonth),
@@ -63,7 +63,7 @@ export async function getDashboard(
       prisma.transaction.aggregate({
         where: {
           userId,
-          category: 'income',
+          transactionType: 'credit',
           transactionDate: {
             gte: startOfMonth(prevMonth),
             lte: endOfMonth(prevMonth),
@@ -75,7 +75,7 @@ export async function getDashboard(
       prisma.transaction.aggregate({
         where: {
           userId,
-          category: { in: ['expense', 'owner-pay'] },
+          transactionType: 'debit',
           transactionDate: {
             gte: startOfMonth(prevMonth),
             lte: endOfMonth(prevMonth),
@@ -134,7 +134,7 @@ async function getCashflowData(
       prisma.transaction.aggregate({
         where: {
           userId,
-          category: 'income',
+          transactionType: 'credit',
           transactionDate: { gte: monthStart, lte: monthEnd },
           ...ownershipWhere,
         },
@@ -143,7 +143,7 @@ async function getCashflowData(
       prisma.transaction.aggregate({
         where: {
           userId,
-          category: { in: ['expense', 'owner-pay'] },
+          transactionType: 'debit',
           transactionDate: { gte: monthStart, lte: monthEnd },
           ...ownershipWhere,
         },


### PR DESCRIPTION
## Summary
- Dashboard and expenses pages filtered transactions by `category` field ('income', 'expense', 'owner-pay')
- Statement processor never assigns categories — transactions have NULL category
- Changed to filter by `transactionType` ('credit' for income, 'debit' for expenses) which is always set

## Test plan
- [ ] Dashboard shows non-zero Monthly Income and Monthly Expenses for months with transaction data
- [ ] Expenses page shows debit transactions grouped by category
- [ ] Cashflow chart populates for months with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)