### PR TITLE
feat: auto-compute daily net worth from transaction history

### DIFF
--- a/prisma/migrations/20260223024811_add_daily_net_worth_tables/migration.sql
+++ b/prisma/migrations/20260223024811_add_daily_net_worth_tables/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "DailyAccountBalance" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "date" DATETIME NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "balance" REAL NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DailyAccountBalance_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "NetWorthAccount" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "DailyAccountBalance_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "DailyNetWorth" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "date" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    "totalAssets" REAL NOT NULL,
+    "totalLiabilities" REAL NOT NULL,
+    "netWorth" REAL NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DailyNetWorth_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "DailyAccountBalance_userId_date_idx" ON "DailyAccountBalance"("userId", "date");
+
+-- CreateIndex
+CREATE INDEX "DailyAccountBalance_accountId_idx" ON "DailyAccountBalance"("accountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DailyAccountBalance_date_accountId_key" ON "DailyAccountBalance"("date", "accountId");
+
+-- CreateIndex
+CREATE INDEX "DailyNetWorth_userId_date_idx" ON "DailyNetWorth"("userId", "date");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DailyNetWorth_userId_date_key" ON "DailyNetWorth"("userId", "date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model User {
   expenseCategories     ExpenseCategory[]
   netWorthAccounts      NetWorthAccount[]
   netWorthSnapshots     NetWorthSnapshot[]
+  dailyAccountBalances  DailyAccountBalance[]
+  dailyNetWorths        DailyNetWorth[]
   scenarios             Scenario[]
 }
 
@@ -451,6 +453,8 @@ model NetWorthAccount {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
+  dailyBalances DailyAccountBalance[]
+
   @@index([userId])
   @@index([userId, accountType])
 }
@@ -468,6 +472,35 @@ model NetWorthSnapshot {
 
   @@unique([userId, date])
   @@index([userId])
+  @@index([userId, date])
+}
+
+model DailyAccountBalance {
+  id        String   @id @default(uuid())
+  date      DateTime // Calendar day (midnight UTC)
+  accountId String
+  account   NetWorthAccount @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  balance   Float    // End-of-day balance for this account
+  createdAt DateTime @default(now())
+
+  @@unique([date, accountId])
+  @@index([userId, date])
+  @@index([accountId])
+}
+
+model DailyNetWorth {
+  id               String   @id @default(uuid())
+  date             DateTime // Calendar day (midnight UTC)
+  userId           String
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  totalAssets      Float
+  totalLiabilities Float
+  netWorth         Float
+  createdAt        DateTime @default(now())
+
+  @@unique([userId, date])
   @@index([userId, date])
 }
 

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -44,6 +44,8 @@ export async function DELETE() {
       await tx.chatTrace.deleteMany({ where: { userId } })
       await tx.chatThread.deleteMany({ where: { userId } })
       await tx.scenario.deleteMany({ where: { userId } })
+      await tx.dailyAccountBalance.deleteMany({ where: { userId } })
+      await tx.dailyNetWorth.deleteMany({ where: { userId } })
       await tx.netWorthSnapshot.deleteMany({ where: { userId } })
       await tx.netWorthAccount.deleteMany({ where: { userId } })
       await tx.expenseCategory.deleteMany({ where: { userId } })

--- a/src/app/api/data/reset/route.ts
+++ b/src/app/api/data/reset/route.ts
@@ -28,6 +28,8 @@ export async function DELETE() {
       await tx.balanceVerification.deleteMany({ where: { statement: { userId } } })
 
       // Delete financial data
+      await tx.dailyAccountBalance.deleteMany({ where: { userId } })
+      await tx.dailyNetWorth.deleteMany({ where: { userId } })
       await tx.netWorthSnapshot.deleteMany({ where: { userId } })
       await tx.netWorthAccount.deleteMany({ where: { userId } })
       await tx.expenseCategory.deleteMany({ where: { userId } })

--- a/src/app/api/net-worth/backfill/route.ts
+++ b/src/app/api/net-worth/backfill/route.ts
@@ -2,7 +2,7 @@ import { headers } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 import { auth } from '@/lib/auth'
-import { takeSnapshot } from '@/lib/services/net-worth'
+import { recomputeDailyNetWorth } from '@/lib/services/daily-net-worth'
 
 export async function POST() {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -10,7 +10,7 @@ export async function POST() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const snapshot = await takeSnapshot(session.user.id)
+  await recomputeDailyNetWorth(session.user.id)
 
-  return NextResponse.json({ snapshot })
+  return NextResponse.json({ success: true })
 }

--- a/src/app/api/net-worth/day/route.ts
+++ b/src/app/api/net-worth/day/route.ts
@@ -1,0 +1,24 @@
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+import { auth } from '@/lib/auth'
+import { getDayDrillDown } from '@/lib/services/daily-net-worth'
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const dateParam = request.nextUrl.searchParams.get('date')
+  if (!dateParam || !/^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
+    return NextResponse.json(
+      { error: 'Missing or invalid date parameter (expected YYYY-MM-DD)' },
+      { status: 400 },
+    )
+  }
+
+  const data = await getDayDrillDown(session.user.id, dateParam)
+
+  return NextResponse.json(data)
+}

--- a/src/app/api/net-worth/history/route.ts
+++ b/src/app/api/net-worth/history/route.ts
@@ -1,9 +1,11 @@
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
+import { subMonths, subYears, startOfDay } from 'date-fns'
 
 import { auth } from '@/lib/auth'
-import { getSnapshots, type HistoryPeriod } from '@/lib/services/net-worth'
+import { getDailyNetWorth } from '@/lib/services/daily-net-worth'
 
+type HistoryPeriod = 'monthly' | 'quarterly' | 'yearly'
 const VALID_PERIODS: HistoryPeriod[] = ['monthly', 'quarterly', 'yearly']
 
 export async function GET(request: NextRequest) {
@@ -17,7 +19,50 @@ export async function GET(request: NextRequest) {
     ? (periodParam as HistoryPeriod)
     : 'monthly'
 
-  const snapshots = await getSnapshots(session.user.id, period)
+  const now = new Date()
+  let since: Date
+
+  switch (period) {
+    case 'monthly':
+      since = startOfDay(subMonths(now, 12))
+      break
+    case 'quarterly':
+      since = startOfDay(subYears(now, 3))
+      break
+    case 'yearly':
+      since = startOfDay(subYears(now, 10))
+      break
+  }
+
+  const dailyData = await getDailyNetWorth(session.user.id, since)
+
+  // For quarterly/yearly views, sample data to reduce density
+  let snapshots = dailyData
+  if (period === 'quarterly') {
+    snapshots = sampleMonthly(dailyData)
+  } else if (period === 'yearly') {
+    snapshots = sampleQuarterly(dailyData)
+  }
 
   return NextResponse.json({ snapshots })
+}
+
+function sampleMonthly(data: typeof getDailyNetWorth extends (...args: never[]) => Promise<infer R> ? R : never) {
+  const byMonth = new Map<string, (typeof data)[number]>()
+  for (const row of data) {
+    const key = row.date.slice(0, 7) // YYYY-MM
+    byMonth.set(key, row) // keep last day of each month
+  }
+  return Array.from(byMonth.values())
+}
+
+function sampleQuarterly(data: typeof getDailyNetWorth extends (...args: never[]) => Promise<infer R> ? R : never) {
+  const byQuarter = new Map<string, (typeof data)[number]>()
+  for (const row of data) {
+    const month = parseInt(row.date.slice(5, 7), 10)
+    const quarter = Math.floor((month - 1) / 3)
+    const key = `${row.date.slice(0, 4)}-Q${quarter}`
+    byQuarter.set(key, row) // keep last day of each quarter
+  }
+  return Array.from(byQuarter.values())
 }

--- a/src/components/net-worth/day-drill-down.tsx
+++ b/src/components/net-worth/day-drill-down.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { format, parseISO } from 'date-fns'
+import { X, ArrowUpRight, ArrowDownRight } from 'lucide-react'
+
+import { formatCurrency, type DayDrillDownData } from '@/lib/services/net-worth-types'
+
+interface DayDrillDownProps {
+  date: string
+  onClose: () => void
+}
+
+export function DayDrillDown({ date, onClose }: DayDrillDownProps) {
+  const [data, setData] = useState<DayDrillDownData | null>(null)
+  const [fetchedDate, setFetchedDate] = useState<string | null>(null)
+
+  const loading = fetchedDate !== date
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`/api/net-worth/day?date=${date}`)
+      .then((res) => res.json())
+      .then((json) => {
+        if (!cancelled) {
+          setData(json)
+          setFetchedDate(date)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setData(null)
+          setFetchedDate(date)
+        }
+      })
+    return () => { cancelled = true }
+  }, [date])
+
+  const formattedDate = format(parseISO(date), 'MMMM d, yyyy')
+
+  const assets = data?.accounts.filter((a) => a.accountType === 'asset') ?? []
+  const liabilities = data?.accounts.filter((a) => a.accountType === 'liability') ?? []
+  const totalAssets = assets.reduce((sum, a) => sum + a.balance, 0)
+  const totalLiabilities = liabilities.reduce((sum, a) => sum + Math.abs(a.balance), 0)
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-medium text-gray-900">
+          {formattedDate}
+        </h3>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1 rounded-md hover:bg-gray-100 transition-colors"
+        >
+          <X className="h-5 w-5 text-gray-400" />
+        </button>
+      </div>
+
+      {loading && (
+        <div className="space-y-3">
+          <div className="h-4 w-48 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-32 bg-gray-200 rounded animate-pulse" />
+          <div className="h-4 w-40 bg-gray-200 rounded animate-pulse" />
+        </div>
+      )}
+
+      {!loading && data && (
+        <div className="space-y-6">
+          {/* Net worth summary for the day */}
+          <div className="grid grid-cols-3 gap-4">
+            <div className="text-center">
+              <p className="text-sm text-gray-500">Assets</p>
+              <p className="text-lg font-semibold text-green-600">
+                {formatCurrency(totalAssets)}
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-sm text-gray-500">Liabilities</p>
+              <p className="text-lg font-semibold text-red-600">
+                {formatCurrency(totalLiabilities)}
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-sm text-gray-500">Net Worth</p>
+              <p className="text-lg font-semibold text-blue-600">
+                {formatCurrency(totalAssets - totalLiabilities)}
+              </p>
+            </div>
+          </div>
+
+          {/* Account balances */}
+          {(assets.length > 0 || liabilities.length > 0) && (
+            <div>
+              <h4 className="text-sm font-medium text-gray-700 mb-2">Account Balances</h4>
+              <div className="space-y-1">
+                {assets.map((a) => (
+                  <div key={a.id} className="flex justify-between text-sm py-1">
+                    <span className="text-gray-600">{a.name}</span>
+                    <span className="font-medium text-green-600">
+                      {formatCurrency(a.balance)}
+                    </span>
+                  </div>
+                ))}
+                {liabilities.map((a) => (
+                  <div key={a.id} className="flex justify-between text-sm py-1">
+                    <span className="text-gray-600">{a.name}</span>
+                    <span className="font-medium text-red-600">
+                      -{formatCurrency(Math.abs(a.balance))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Transactions for this day */}
+          {data.transactions.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-gray-700 mb-2">
+                Transactions ({data.transactions.length})
+              </h4>
+              <div className="space-y-1 max-h-64 overflow-y-auto">
+                {data.transactions.map((tx) => (
+                  <div key={tx.id} className="flex items-center justify-between text-sm py-1.5 border-b border-gray-50 last:border-0">
+                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                      <div className={`p-1 rounded ${tx.amount >= 0 ? 'bg-green-50' : 'bg-red-50'}`}>
+                        {tx.amount >= 0
+                          ? <ArrowUpRight className="h-3 w-3 text-green-600" />
+                          : <ArrowDownRight className="h-3 w-3 text-red-600" />
+                        }
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-gray-700 truncate">{tx.description}</p>
+                        <p className="text-xs text-gray-400">{tx.accountName}</p>
+                      </div>
+                    </div>
+                    <span className={`font-medium ml-2 whitespace-nowrap ${tx.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {tx.amount >= 0 ? '+' : ''}{formatCurrency(tx.amount)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {data.transactions.length === 0 && (
+            <p className="text-sm text-gray-400 italic">
+              No transactions on this day. Balances carried forward from the previous day.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/services/daily-net-worth.ts
+++ b/src/lib/services/daily-net-worth.ts
@@ -1,0 +1,340 @@
+import {
+  startOfDay,
+  addDays,
+  isBefore,
+  isAfter,
+  format,
+} from 'date-fns'
+
+import { prisma } from '@/lib/prisma'
+
+/**
+ * Recompute daily net worth snapshots for a user.
+ *
+ * Approach:
+ * 1. Load all transactions grouped by their linked NetWorthAccount (via bankAccountId).
+ * 2. For each account, walk calendar days from the statement's opening balance date
+ *    through today, accumulating transaction amounts to derive end-of-day balance.
+ * 3. For days with no transactions, carry forward the previous day's balance.
+ * 4. Upsert DailyAccountBalance rows (dense — every calendar day).
+ * 5. Aggregate all accounts per day into DailyNetWorth (totalAssets, totalLiabilities, netWorth).
+ */
+export async function recomputeDailyNetWorth(userId: string): Promise<void> {
+  const today = startOfDay(new Date())
+
+  // Get all active net worth accounts linked to bank accounts
+  const netWorthAccounts = await prisma.netWorthAccount.findMany({
+    where: { userId, isActive: true },
+  })
+
+  // For accounts linked to bank accounts, compute daily balances from transactions
+  const linkedAccounts = netWorthAccounts.filter((a) => a.bankAccountId)
+  const manualAccounts = netWorthAccounts.filter((a) => !a.bankAccountId)
+
+  // Map bankAccountId → netWorthAccount for quick lookup
+  const bankToNwAccount = new Map(
+    linkedAccounts.map((a) => [a.bankAccountId!, a]),
+  )
+
+  // Load all statements for linked bank accounts to get opening balances & periods
+  const bankAccountIds = linkedAccounts
+    .map((a) => a.bankAccountId!)
+    .filter(Boolean)
+
+  const statements = bankAccountIds.length > 0
+    ? await prisma.bankStatement.findMany({
+        where: {
+          userId,
+          bankAccountId: { in: bankAccountIds },
+          isProcessed: true,
+        },
+        orderBy: { periodStart: 'asc' },
+        select: {
+          id: true,
+          bankAccountId: true,
+          openingBalance: true,
+          periodStart: true,
+          periodEnd: true,
+        },
+      })
+    : []
+
+  // Load all transactions for these statements
+  const statementIds = statements.map((s) => s.id)
+  const transactions = statementIds.length > 0
+    ? await prisma.transaction.findMany({
+        where: {
+          userId,
+          statementId: { in: statementIds },
+        },
+        orderBy: { transactionDate: 'asc' },
+        select: {
+          statementId: true,
+          transactionDate: true,
+          amount: true,
+        },
+      })
+    : []
+
+  // Group statements by bankAccountId
+  const statementsByBank = new Map<string, typeof statements>()
+  for (const s of statements) {
+    if (!s.bankAccountId) continue
+    const arr = statementsByBank.get(s.bankAccountId) || []
+    arr.push(s)
+    statementsByBank.set(s.bankAccountId, arr)
+  }
+
+  // Group transactions by statementId
+  const txByStatement = new Map<string, typeof transactions>()
+  for (const tx of transactions) {
+    if (!tx.statementId) continue
+    const arr = txByStatement.get(tx.statementId) || []
+    arr.push(tx)
+    txByStatement.set(tx.statementId, arr)
+  }
+
+  // For each linked account, compute daily balances
+  // accountDailyBalances: Map<accountId, Map<dateString, balance>>
+  const accountDailyBalances = new Map<string, Map<string, number>>()
+
+  for (const [bankAccountId, nwAccount] of bankToNwAccount) {
+    const stmts = statementsByBank.get(bankAccountId) || []
+    if (stmts.length === 0) continue
+
+    // Sort by periodStart to process chronologically
+    stmts.sort((a, b) => (a.periodStart?.getTime() ?? 0) - (b.periodStart?.getTime() ?? 0))
+
+    const dailyMap = new Map<string, number>()
+
+    for (const stmt of stmts) {
+      if (!stmt.periodStart || !stmt.periodEnd || stmt.openingBalance === null) continue
+
+      const stmtTxs = txByStatement.get(stmt.id) || []
+
+      // Build a map of date → total transaction amount for this statement
+      const txByDate = new Map<string, number>()
+      for (const tx of stmtTxs) {
+        const dateKey = format(startOfDay(tx.transactionDate), 'yyyy-MM-dd')
+        txByDate.set(dateKey, (txByDate.get(dateKey) || 0) + tx.amount)
+      }
+
+      // Walk each calendar day from periodStart to periodEnd
+      let runningBalance = stmt.openingBalance
+      let day = startOfDay(stmt.periodStart)
+      const endDay = startOfDay(stmt.periodEnd)
+
+      while (!isAfter(day, endDay)) {
+        const dateKey = format(day, 'yyyy-MM-dd')
+        const dayAmount = txByDate.get(dateKey) || 0
+        runningBalance += dayAmount
+        dailyMap.set(dateKey, runningBalance)
+        day = addDays(day, 1)
+      }
+    }
+
+    // Extend to today by carrying forward the last known balance
+    if (dailyMap.size > 0) {
+      const sortedDates = Array.from(dailyMap.keys()).sort()
+      const lastDate = sortedDates[sortedDates.length - 1]
+      const lastBalance = dailyMap.get(lastDate)!
+      let day = addDays(startOfDay(new Date(lastDate + 'T00:00:00')), 1)
+
+      while (!isAfter(day, today)) {
+        const dateKey = format(day, 'yyyy-MM-dd')
+        dailyMap.set(dateKey, lastBalance)
+        day = addDays(day, 1)
+      }
+    }
+
+    accountDailyBalances.set(nwAccount.id, dailyMap)
+  }
+
+  // For manual accounts, use their currentBalance for every day that any linked account has data
+  // (manual accounts don't have transaction history, so we assume constant balance)
+  const allDates = new Set<string>()
+  for (const dailyMap of accountDailyBalances.values()) {
+    for (const dateKey of dailyMap.keys()) {
+      allDates.add(dateKey)
+    }
+  }
+
+  for (const manual of manualAccounts) {
+    const dailyMap = new Map<string, number>()
+    for (const dateKey of allDates) {
+      dailyMap.set(dateKey, manual.currentBalance)
+    }
+    accountDailyBalances.set(manual.id, dailyMap)
+  }
+
+  // Build type lookup
+  const accountTypeMap = new Map(
+    netWorthAccounts.map((a) => [a.id, a.accountType]),
+  )
+
+  // Upsert DailyAccountBalance rows in batch
+  // Delete existing and recreate for simplicity (within a transaction)
+  await prisma.$transaction(async (tx) => {
+    // Clear existing daily data for this user
+    await tx.dailyAccountBalance.deleteMany({ where: { userId } })
+    await tx.dailyNetWorth.deleteMany({ where: { userId } })
+
+    // Batch create DailyAccountBalance
+    const balanceRows: {
+      date: Date
+      accountId: string
+      userId: string
+      balance: number
+    }[] = []
+
+    for (const [accountId, dailyMap] of accountDailyBalances) {
+      for (const [dateKey, balance] of dailyMap) {
+        balanceRows.push({
+          date: new Date(dateKey + 'T00:00:00.000Z'),
+          accountId,
+          userId,
+          balance,
+        })
+      }
+    }
+
+    if (balanceRows.length > 0) {
+      await tx.dailyAccountBalance.createMany({ data: balanceRows })
+    }
+
+    // Aggregate into DailyNetWorth
+    const sortedDates = Array.from(allDates).sort()
+    const netWorthRows: {
+      date: Date
+      userId: string
+      totalAssets: number
+      totalLiabilities: number
+      netWorth: number
+    }[] = []
+
+    for (const dateKey of sortedDates) {
+      let totalAssets = 0
+      let totalLiabilities = 0
+
+      for (const [accountId, dailyMap] of accountDailyBalances) {
+        const balance = dailyMap.get(dateKey)
+        if (balance === undefined) continue
+
+        const accountType = accountTypeMap.get(accountId)
+        if (accountType === 'asset') {
+          totalAssets += balance
+        } else {
+          totalLiabilities += Math.abs(balance)
+        }
+      }
+
+      netWorthRows.push({
+        date: new Date(dateKey + 'T00:00:00.000Z'),
+        userId,
+        totalAssets,
+        totalLiabilities,
+        netWorth: totalAssets - totalLiabilities,
+      })
+    }
+
+    if (netWorthRows.length > 0) {
+      await tx.dailyNetWorth.createMany({ data: netWorthRows })
+    }
+  })
+}
+
+/**
+ * Get daily net worth data for chart display.
+ */
+export async function getDailyNetWorth(
+  userId: string,
+  since?: Date,
+): Promise<{ date: string; totalAssets: number; totalLiabilities: number; netWorth: number }[]> {
+  const rows = await prisma.dailyNetWorth.findMany({
+    where: {
+      userId,
+      ...(since ? { date: { gte: since } } : {}),
+    },
+    orderBy: { date: 'asc' },
+  })
+
+  return rows.map((r) => ({
+    date: format(r.date, 'yyyy-MM-dd'),
+    totalAssets: r.totalAssets,
+    totalLiabilities: r.totalLiabilities,
+    netWorth: r.netWorth,
+  }))
+}
+
+/**
+ * Get drill-down data for a specific date: per-account balances and transactions.
+ */
+export async function getDayDrillDown(
+  userId: string,
+  dateStr: string,
+): Promise<{
+  date: string
+  accounts: {
+    id: string
+    name: string
+    accountType: string
+    category: string
+    balance: number
+  }[]
+  transactions: {
+    id: string
+    description: string
+    amount: number
+    transactionDate: string
+    accountName: string
+  }[]
+}> {
+  const dayStart = new Date(dateStr + 'T00:00:00.000Z')
+  const dayEnd = new Date(dateStr + 'T23:59:59.999Z')
+
+  // Get per-account balances for this day
+  const balances = await prisma.dailyAccountBalance.findMany({
+    where: { userId, date: dayStart },
+    include: {
+      account: {
+        select: { id: true, name: true, accountType: true, category: true },
+      },
+    },
+  })
+
+  // Get transactions for this day
+  const transactions = await prisma.transaction.findMany({
+    where: {
+      userId,
+      transactionDate: { gte: dayStart, lte: dayEnd },
+    },
+    orderBy: { transactionDate: 'asc' },
+    include: {
+      statement: {
+        select: {
+          bankAccount: {
+            select: { nickname: true },
+          },
+        },
+      },
+    },
+  })
+
+  return {
+    date: dateStr,
+    accounts: balances.map((b) => ({
+      id: b.account.id,
+      name: b.account.name,
+      accountType: b.account.accountType,
+      category: b.account.category,
+      balance: b.balance,
+    })),
+    transactions: transactions.map((tx) => ({
+      id: tx.id,
+      description: tx.description,
+      amount: tx.amount,
+      transactionDate: format(tx.transactionDate, 'yyyy-MM-dd'),
+      accountName: tx.statement?.bankAccount?.nickname ?? 'Unknown',
+    })),
+  }
+}

--- a/src/lib/services/net-worth-types.ts
+++ b/src/lib/services/net-worth-types.ts
@@ -65,6 +65,31 @@ export interface NetWorthSnapshotData {
   netWorth: number
 }
 
+export interface DailyNetWorthData {
+  date: string
+  totalAssets: number
+  totalLiabilities: number
+  netWorth: number
+}
+
+export interface DayDrillDownData {
+  date: string
+  accounts: {
+    id: string
+    name: string
+    accountType: string
+    category: string
+    balance: number
+  }[]
+  transactions: {
+    id: string
+    description: string
+    amount: number
+    transactionDate: string
+    accountName: string
+  }[]
+}
+
 export interface NetWorthSummary {
   netWorth: number
   totalAssets: number

--- a/src/lib/services/statement-processor.ts
+++ b/src/lib/services/statement-processor.ts
@@ -6,6 +6,7 @@ import {
 } from 'openai/resources/chat/completions.mjs'
 import { reconcileProvisionalTransactions } from '@/lib/services/plaid-sync'
 import { categorizeTransactions } from '@/lib/services/transaction-categorizer'
+import { recomputeDailyNetWorth } from '@/lib/services/daily-net-worth'
 import { readFile } from 'fs/promises'
 import { getUploadFullPath } from '@/lib/upload-path'
 
@@ -178,6 +179,14 @@ export async function processStatement(
   } catch (error) {
     console.error('Auto-categorization error:', error)
     // Non-fatal: transactions are still saved, just uncategorized
+  }
+
+  // Recompute daily net worth snapshots from transaction history
+  try {
+    await recomputeDailyNetWorth(userId)
+  } catch (error) {
+    console.error('Daily net worth recomputation error:', error)
+    // Non-fatal: statement processing still succeeds
   }
 
   return {


### PR DESCRIPTION
## Summary
- Replaces manual snapshot UX with auto-computed dense daily net worth data derived from bank statement transactions
- After each statement is processed, daily balances are recomputed per account and aggregated into `DailyNetWorth` rows for chart display
- Chart now shows daily granularity with click-to-drill-down showing per-account balances and transactions for any day
- Removed the manual "Snapshot" button — net worth chart now auto-populates from processed statements

## Changes
- **Schema**: Added `DailyAccountBalance` and `DailyNetWorth` models with migration
- **Service**: New `daily-net-worth.ts` — `recomputeDailyNetWorth()` walks transactions day-by-day, fills dense calendar rows
- **Statement processor**: Hooks `recomputeDailyNetWorth` after categorization
- **API**: New `/api/net-worth/day?date=YYYY-MM-DD` drill-down endpoint, updated `/api/net-worth/history` to serve daily data, added `/api/net-worth/backfill` for existing data, removed `/api/net-worth/snapshot`
- **UI**: Updated chart with click handler, new `DayDrillDown` component, removed Snapshot button
- **Cleanup**: Updated data reset + account delete routes for new tables, removed dead `takeSnapshot`/`getSnapshots` code

## Test plan
- [ ] Upload a bank statement → verify net worth chart auto-populates with daily data
- [ ] Click a point on the chart → verify drill-down shows account balances and transactions
- [ ] Call `POST /api/net-worth/backfill` → verify existing processed statements generate daily data
- [ ] Verify Snapshot button is gone from net worth page
- [ ] Run `npx tsc --noEmit` — passes
- [ ] Run `yarn build` — passes
- [ ] Run `yarn lint` — passes

Closes NAN-470

🤖 Generated with [Claude Code](https://claude.com/claude-code)