### PR TITLE
fix: prevent duplicate document entries when uploading statements

### DIFF
--- a/prisma/migrations/20260223032642_add_content_hash_to_document/migration.sql
+++ b/prisma/migrations/20260223032642_add_content_hash_to_document/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Document" ADD COLUMN "contentHash" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Document_contentHash_idx" ON "Document"("contentHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -362,6 +362,7 @@ model Document {
   documentType      String   @default("other") // statement | tax | investment | receipt | other
   tags              String?  // Comma-separated tags
   description       String?
+  contentHash       String?  // SHA-256 hash for dedup
   googleDriveFileId String?  // Google Drive file ID for tracking imported files
   uploadedAt        DateTime @default(now())
   createdAt         DateTime @default(now())
@@ -369,6 +370,7 @@ model Document {
 
   @@index([userId])
   @@index([userId, documentType])
+  @@index([contentHash])
   @@index([googleDriveFileId])
 }
 


### PR DESCRIPTION
## Summary
- Statement PDFs now only create a `BankStatement` record (no longer also a `Document`), eliminating duplicate entries in the Documents list
- Added SHA-256 content hash dedup — re-uploading the same file returns HTTP 409
- Documents page query now excludes `documentType: 'statement'` from Document table as a safety net for legacy data
- New migration adds `contentHash` column + index to `Document` model

Closes NAN-469

## Test plan
- [ ] Upload a PDF classified as a bank statement — verify only ONE entry appears in Documents list
- [ ] Upload the same PDF again — verify it's rejected as a duplicate (409)
- [ ] Upload a non-statement document — verify it still appears correctly
- [ ] Check existing documents still display properly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)