### PR TITLE
fix: restore browse files/folders in upload modal + increase file size limit

### DIFF
--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -63,9 +63,9 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const maxSize = 10 * 1024 * 1024
+  const maxSize = 50 * 1024 * 1024
   if (file.size > maxSize) {
-    return NextResponse.json({ error: 'File size exceeds 10MB limit' }, { status: 400 })
+    return NextResponse.json({ error: 'File size exceeds 50MB limit' }, { status: 400 })
   }
 
   const { relPath, fullPath, sanitizedFileName } = await prepareUpload(session.user.id, file.name)

--- a/src/app/api/upload/bulk/route.ts
+++ b/src/app/api/upload/bulk/route.ts
@@ -64,8 +64,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'No files provided' }, { status: 400 })
   }
 
-  const maxSize = 10 * 1024 * 1024 // 10MB per file
-  const maxTotalSize = 100 * 1024 * 1024 // 100MB total
+  const maxSize = 50 * 1024 * 1024 // 50MB per file
+  const maxTotalSize = 500 * 1024 * 1024 // 500MB total
   const uploaded: UploadedFile[] = []
   const errors: { fileName: string, error: string }[] = []
 
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest) {
 
   if (totalSize > maxTotalSize) {
     return NextResponse.json(
-      { error: 'Total upload size exceeds 100MB limit' },
+      { error: 'Total upload size exceeds 500MB limit' },
       { status: 400 },
     )
   }
@@ -86,7 +86,7 @@ export async function POST(request: NextRequest) {
       if (file.name.toLowerCase().endsWith('.zip')) {
         // Handle zip file — extract PDFs
         if (file.size > maxTotalSize) {
-          errors.push({ fileName: file.name, error: 'Zip file exceeds 100MB limit' })
+          errors.push({ fileName: file.name, error: 'Zip file exceeds 500MB limit' })
           continue
         }
 
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
 
         for (const pdf of pdfs) {
           if (pdf.buffer.length > maxSize) {
-            errors.push({ fileName: pdf.name, error: 'File exceeds 10MB limit' })
+            errors.push({ fileName: pdf.name, error: 'File exceeds 50MB limit' })
             continue
           }
 
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
       } else if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
         // Handle individual PDF
         if (file.size > maxSize) {
-          errors.push({ fileName: file.name, error: 'File exceeds 10MB limit' })
+          errors.push({ fileName: file.name, error: 'File exceeds 50MB limit' })
           continue
         }
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -40,9 +40,9 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const maxSize = 10 * 1024 * 1024
+  const maxSize = 50 * 1024 * 1024
   if (file.size > maxSize) {
-    return NextResponse.json({ error: 'File size exceeds 10MB limit' }, { status: 400 })
+    return NextResponse.json({ error: 'File size exceeds 50MB limit' }, { status: 400 })
   }
 
   const { relPath, fullPath, sanitizedFileName } = await prepareUpload(session.user.id, file.name)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,3 +81,13 @@ body {
   color: var(--foreground);
   font-family: var(--font-body);
 }
+
+/*
+ * Tailwind CSS v4 preflight sets [hidden] { display: none !important },
+ * which breaks Uppy Dashboard's hidden file inputs. Uppy relies on
+ * visually-hidden (not display:none) inputs so .click() can trigger
+ * the native file picker. Override with Uppy's own positioning strategy.
+ */
+.uppy-Dashboard-input[hidden] {
+  display: block !important;
+}

--- a/src/components/documents/document-uploader.tsx
+++ b/src/components/documents/document-uploader.tsx
@@ -53,7 +53,7 @@ export function DocumentUploadZone({ children }: DocumentUploadZoneProps) {
   const [uppy] = useState(() => {
     const instance = new Uppy<Meta, Body>({
       restrictions: {
-        maxFileSize: 10 * 1024 * 1024,
+        maxFileSize: 50 * 1024 * 1024,
         maxNumberOfFiles: 20,
         allowedFileTypes: ['.pdf', '.md', '.csv', '.txt', '.jpg', '.jpeg', '.png', '.xlsx', '.xls'],
       },
@@ -305,7 +305,7 @@ export function DocumentUploadZone({ children }: DocumentUploadZoneProps) {
         open={modalOpen}
         onRequestClose={() => setModalOpen(false)}
         proudlyDisplayPoweredByUppy={false}
-        note="PDF, Markdown, CSV, Text, Images, Excel up to 10 MB"
+        note="PDF, Markdown, CSV, Text, Images, Excel up to 50 MB"
         showRemoveButtonAfterComplete
         fileManagerSelectionType="both"
         doneButtonHandler={() => {

--- a/src/components/statements/statement-uploader.tsx
+++ b/src/components/statements/statement-uploader.tsx
@@ -50,9 +50,9 @@ export function StatementUploader() {
       <UppyUploader
         endpoint="/api/upload"
         allowedFileTypes={['.pdf']}
-        maxFileSize={10 * 1024 * 1024}
+        maxFileSize={50 * 1024 * 1024}
         maxNumberOfFiles={50}
-        note="PDF bank statements up to 10 MB each"
+        note="PDF bank statements up to 50 MB each"
         onUploadComplete={handleUploadComplete}
         height={300}
       />


### PR DESCRIPTION
## Summary
- Fixed "browse files" and "browse folders" links in upload modal not working
- Root cause: Tailwind CSS v4 preflight sets `[hidden] { display: none !important }` which breaks Uppy Dashboard's hidden file inputs that rely on being visually hidden (not display:none) for `.click()` to work
- Fix: CSS override `.uppy-Dashboard-input[hidden] { display: block !important }` in globals.css
- Increased file size limit from 10 MB to 50 MB across all upload routes and client-side Uppy configs

Closes NAN-476

## Test plan
- [ ] Open upload modal → click "browse files" → native file picker opens
- [ ] Open upload modal → click "browse folders" → native folder picker opens
- [ ] Drag-and-drop into modal still works
- [ ] Drag-and-drop onto page (hidden drop zone) still works
- [ ] Upload a file > 10 MB but < 50 MB → succeeds
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)