### PR TITLE
feat: add delete button for bank accounts in settings

### DIFF
--- a/src/app/(private)/settings/actions.ts
+++ b/src/app/(private)/settings/actions.ts
@@ -73,3 +73,59 @@ export async function updateAccount(
   revalidatePath('/settings')
   return { success: true }
 }
+
+export async function getAccountStats(accountId: string) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return { success: false as const, error: 'Unauthorized' }
+
+  const account = await prisma.bankAccount.findFirst({
+    where: { id: accountId, userId: session.user.id },
+  })
+  if (!account) return { success: false as const, error: 'Account not found' }
+
+  const statementCount = await prisma.bankStatement.count({
+    where: { bankAccountId: accountId },
+  })
+
+  const transactionCount = await prisma.transaction.count({
+    where: { statement: { bankAccountId: accountId } },
+  })
+
+  return {
+    success: true as const,
+    statementCount,
+    transactionCount,
+  }
+}
+
+export async function deleteAccount(accountId: string) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return { success: false, error: 'Unauthorized' }
+
+  const account = await prisma.bankAccount.findFirst({
+    where: { id: accountId, userId: session.user.id },
+  })
+  if (!account) return { success: false, error: 'Account not found' }
+
+  await prisma.$transaction(async (tx) => {
+    // Unlink statements (set bankAccountId to null)
+    await tx.bankStatement.updateMany({
+      where: { bankAccountId: accountId },
+      data: { bankAccountId: null },
+    })
+
+    // Unlink net worth accounts (set bankAccountId to null)
+    await tx.netWorthAccount.updateMany({
+      where: { bankAccountId: accountId },
+      data: { bankAccountId: null },
+    })
+
+    // Delete the bank account
+    await tx.bankAccount.delete({
+      where: { id: accountId },
+    })
+  })
+
+  revalidatePath('/settings')
+  return { success: true }
+}


### PR DESCRIPTION
## Summary
- Adds a trash icon button per bank account card on the Settings page
- Confirmation dialog shows "Delete this account? This will unlink X statements and Y transactions."
- Deletion unlinks (sets `bankAccountId = null`) associated statements and net worth accounts via server actions
- No new API routes — uses Next.js server actions in `settings/actions.ts`

Closes NAN-471

## Test plan
- [ ] Settings page shows trash icon on each bank account card
- [ ] Clicking trash opens confirmation dialog with correct counts
- [ ] Confirming delete removes the account and unlinks statements
- [ ] Cancelled delete does nothing
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)