### PR TITLE
feat: simplify nav and merge net worth into dashboard

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -72,8 +72,9 @@ test.describe('Auth Flow', () => {
     await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 })
     await expect(page.getByText('OpenFinance').first()).toBeVisible()
 
-    // Sign out
-    await page.getByRole('button', { name: /sign out/i }).click()
+    // Sign out via profile dropdown
+    await page.getByRole('button', { name: 'User menu' }).click()
+    await page.getByRole('menuitem', { name: /sign out/i }).click()
     await expect(page).toHaveURL(/\/auth\/login/, { timeout: 10_000 })
 
     // Log back in

--- a/e2e/production.spec.ts
+++ b/e2e/production.spec.ts
@@ -49,8 +49,9 @@ test.describe('Production Deployment', () => {
     await page.goto(`${PROD_URL}/settings`)
     await expect(page).toHaveURL(/\/settings/)
 
-    // Sign out
-    await page.getByRole('button', { name: /sign out/i }).click()
+    // Sign out via profile dropdown
+    await page.getByRole('button', { name: 'User menu' }).click()
+    await page.getByRole('menuitem', { name: /sign out/i }).click()
     await expect(page).toHaveURL(/\/auth\/login/, { timeout: 10_000 })
   })
 })

--- a/src/app/(private)/dashboard/page.tsx
+++ b/src/app/(private)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/services/dashboard'
 import { CashflowChart } from '@/components/dashboard/cashflow-chart'
 import { OwnershipFilter } from '@/components/dashboard/ownership-filter'
+import { NetWorthDashboard } from '@/components/net-worth/net-worth-dashboard'
 
 interface DashboardPageProps {
   searchParams: Promise<{ ownership?: OwnershipFilterType }>
@@ -74,8 +75,8 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
   ]
 
   return (
-    <div>
-      <div className="mb-8 flex items-start justify-between">
+    <div className="space-y-8">
+      <div className="flex items-start justify-between">
         <div>
           <h1 className="text-3xl font-semibold text-gray-900">
             Welcome back{session.user.name ? `, ${session.user.name}` : ''}
@@ -88,7 +89,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       </div>
 
       {totalTransactions === 0 && (
-        <div className="mb-8 rounded-lg border border-gray-200 bg-white p-10 text-center">
+        <div className="rounded-lg border border-gray-200 bg-white p-10 text-center">
           <h2 className="text-lg font-semibold text-gray-900">No transactions yet</h2>
           <p className="mt-2 text-sm text-gray-500">
             Upload a bank statement to automatically extract and categorize your transactions.
@@ -102,7 +103,10 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
         </div>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+      {/* Net Worth section */}
+      <NetWorthDashboard embedded />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {statsCards.map((stat, index) => {
           const Icon = stat.icon
           const changePercent = stat.changePercent

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import {
   Home,
   Receipt,
@@ -14,28 +14,30 @@ import {
   Menu,
   X,
   ListChecks,
-  Landmark,
-  TrendingUp,
 } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { authClient, useSession } from '@/lib/auth-client'
-import { Button } from '@/components/ui/button'
 import { UserAvatar } from '@/components/user-avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 const navItems = [
   { href: '/chat', label: 'Home', icon: MessageSquare },
   { href: '/dashboard', label: 'Dashboard', icon: Home },
-  { href: '/net-worth', label: 'Net Worth', icon: Landmark },
-  { href: '/scenarios', label: 'Scenarios', icon: TrendingUp },
   { href: '/transactions', label: 'Transactions', icon: Receipt },
   { href: '/expenses', label: 'Expenses', icon: PieChart },
   { href: '/documents', label: 'Documents', icon: FolderOpen },
-  { href: '/jobs', label: 'Jobs', icon: ListChecks },
 ]
 
 export function Navbar() {
   const pathname = usePathname()
+  const router = useRouter()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const { data: session } = useSession()
 
@@ -98,22 +100,36 @@ export function Navbar() {
               })}
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Link href="/settings" className="rounded-full transition-opacity hover:opacity-80">
-              <UserAvatar
-                name={session?.user?.name}
-                image={session?.user?.image}
-              />
-            </Link>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleSignOut}
-              className="text-gray-600 hover:text-gray-900"
-            >
-              <LogOut className="h-4 w-4" />
-              <span className="hidden md:inline">Sign out</span>
-            </Button>
+          <div className="flex items-center">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="User menu"
+                  className="rounded-full transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2"
+                >
+                  <UserAvatar
+                    name={session?.user?.name}
+                    image={session?.user?.image}
+                  />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem onClick={() => router.push('/jobs')}>
+                  <ListChecks className="h-4 w-4" />
+                  Jobs
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => router.push('/settings')}>
+                  <Settings className="h-4 w-4" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleSignOut}>
+                  <LogOut className="h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>
@@ -147,6 +163,19 @@ export function Navbar() {
             )
           })}
           <div className="border-t border-gray-200 my-1 pt-1">
+            <Link
+              href="/jobs"
+              onClick={closeMobileMenu}
+              className={cn(
+                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                pathname.startsWith('/jobs')
+                  ? 'bg-gray-100 text-gray-900'
+                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50',
+              )}
+            >
+              <ListChecks className="h-4 w-4" />
+              Jobs
+            </Link>
             <Link
               href="/settings"
               onClick={closeMobileMenu}

--- a/src/components/net-worth/net-worth-dashboard.tsx
+++ b/src/components/net-worth/net-worth-dashboard.tsx
@@ -35,7 +35,11 @@ interface NetWorthData {
   }
 }
 
-export function NetWorthDashboard() {
+interface NetWorthDashboardProps {
+  embedded?: boolean
+}
+
+export function NetWorthDashboard({ embedded = false }: NetWorthDashboardProps) {
   const [data, setData] = useState<NetWorthData | null>(null)
   const [snapshots, setSnapshots] = useState<DailyNetWorthData[]>([])
   const [period, setPeriod] = useState<HistoryPeriod>('monthly')
@@ -116,10 +120,16 @@ export function NetWorthDashboard() {
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-3xl font-semibold text-gray-900">Net Worth</h1>
-          <p className="mt-1 text-gray-600">
-            Track your assets, liabilities, and net worth over time.
-          </p>
+          {embedded ? (
+            <h2 className="text-lg font-medium text-gray-900">Net Worth</h2>
+          ) : (
+            <>
+              <h1 className="text-3xl font-semibold text-gray-900">Net Worth</h1>
+              <p className="mt-1 text-gray-600">
+                Track your assets, liabilities, and net worth over time.
+              </p>
+            </>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Button

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-gray-200 bg-white p-1 text-gray-950 shadow-md',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-gray-100 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      'px-2 py-1.5 text-sm font-semibold',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-gray-100', className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+}


### PR DESCRIPTION
## Summary
- Reduced main nav from 8 items to 5: Home, Dashboard, Transactions, Expenses, Documents
- Added profile avatar dropdown with: Jobs, Settings, Sign out
- Embedded NetWorthDashboard as headline section of Dashboard page (with `embedded` prop for compact header)
- Added new shadcn/ui `dropdown-menu.tsx` component
- Updated E2E tests (auth + production) for the new sign-out flow via dropdown
- Pages still accessible at their URLs (/net-worth, /scenarios, /jobs) — just removed from nav

Closes NAN-477

## Test plan
- [ ] Nav shows only 5 items: Home, Dashboard, Transactions, Expenses, Documents
- [ ] Clicking avatar opens dropdown with Jobs, Settings, Sign out
- [ ] Sign out via dropdown works correctly
- [ ] Dashboard page shows Net Worth section at the top
- [ ] /net-worth, /scenarios, /jobs pages still accessible directly
- [ ] E2E tests pass
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)