### PR TITLE
fix: recalculate net worth after deleting statements/accounts

### DIFF
--- a/src/app/(private)/settings/actions.ts
+++ b/src/app/(private)/settings/actions.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from 'next/cache'
 
 import { encrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
+import { recalculateNetWorth } from '@/lib/services/daily-net-worth'
 
 export async function updateSettings(data: {
   fiscalYearEndMonth?: number
@@ -126,6 +127,10 @@ export async function deleteAccount(accountId: string) {
     })
   })
 
+  await recalculateNetWorth(session.user.id)
+
   revalidatePath('/settings')
+  revalidatePath('/net-worth')
+  revalidatePath('/dashboard')
   return { success: true }
 }

--- a/src/app/(private)/statements/actions.ts
+++ b/src/app/(private)/statements/actions.ts
@@ -5,6 +5,7 @@ import { headers } from 'next/headers'
 import { prisma } from '@/lib/prisma'
 import { revalidatePath } from 'next/cache'
 import { processStatementById } from '@/lib/services/statement-processor'
+import { recalculateNetWorth } from '@/lib/services/daily-net-worth'
 
 export async function toggleHumanVerified(statementId: string) {
   const session = await auth.api.getSession({ headers: await headers() })
@@ -64,7 +65,11 @@ export async function deleteStatement(statementId: string) {
     where: { id: statementId },
   })
 
+  await recalculateNetWorth(session.user.id)
+
   revalidatePath('/statements')
+  revalidatePath('/net-worth')
+  revalidatePath('/dashboard')
 
   return { success: true }
 }

--- a/src/app/api/documents/statements/[id]/route.ts
+++ b/src/app/api/documents/statements/[id]/route.ts
@@ -1,7 +1,9 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
+
 import { prisma } from '@/lib/prisma'
+import { recalculateNetWorth } from '@/lib/services/daily-net-worth'
 
 export async function DELETE(
   _request: NextRequest,
@@ -23,6 +25,8 @@ export async function DELETE(
   }
 
   await prisma.bankStatement.delete({ where: { id } })
+
+  await recalculateNetWorth(session.user.id)
 
   return NextResponse.json({ success: true })
 }

--- a/src/app/api/net-worth/accounts/[id]/route.ts
+++ b/src/app/api/net-worth/accounts/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { auth } from '@/lib/auth'
 import { updateAccount, deactivateAccount } from '@/lib/services/net-worth'
+import { recomputeDailyNetWorth } from '@/lib/services/daily-net-worth'
 import {
   ASSET_CATEGORIES,
   LIABILITY_CATEGORIES,
@@ -86,6 +87,8 @@ export async function DELETE(
   if (!success) {
     return NextResponse.json({ error: 'Account not found' }, { status: 404 })
   }
+
+  await recomputeDailyNetWorth(session.user.id)
 
   return NextResponse.json({ success: true })
 }

--- a/src/app/api/plaid/connections/[id]/route.ts
+++ b/src/app/api/plaid/connections/[id]/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { decrypt } from '@/lib/encryption'
 import { prisma } from '@/lib/prisma'
 import { getPlaidClientForUser } from '@/lib/plaid'
+import { recalculateNetWorth } from '@/lib/services/daily-net-worth'
 
 export async function DELETE(
   _request: NextRequest,
@@ -48,6 +49,8 @@ export async function DELETE(
   await prisma.plaidConnection.delete({
     where: { id },
   })
+
+  await recalculateNetWorth(session.user.id)
 
   return NextResponse.json({ success: true })
 }


### PR DESCRIPTION
## Summary
- New `recalculateNetWorth(userId)` function that updates account balances from remaining statements and rebuilds daily snapshots
- Wired into all delete paths:
  - Statement deletion (server action + API route)
  - Bank account deletion (server action)
  - Plaid connection removal (API route)
  - Net worth account deactivation (API route)
- Dashboard and Net Worth pages revalidated after deletions

Closes NAN-481

## Test plan
- [ ] Delete a statement → net worth updates to reflect removed transactions
- [ ] Delete a bank account → net worth recalculates without that account
- [ ] Delete all statements for an account → balance goes to 0
- [ ] Dashboard Net Worth section reflects changes immediately
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)