### PR TITLE
fix: classify credit card accounts as liabilities instead of assets

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -4,9 +4,13 @@ export const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 })
 
+export type StatementAccountType = 'chequing' | 'savings' | 'credit_card' | 'line_of_credit' | 'loan'
+
 export interface BankStatementData {
   bankName: string
+  accountName?: string
   accountNumber: string
+  accountType?: StatementAccountType
   statementDate?: string
   periodStart: string
   periodEnd: string


### PR DESCRIPTION
## Summary
- AI extraction prompt now detects account type from statement content (chequing, savings, credit_card, line_of_credit, loan)
- Credit cards detected via keywords: Mastercard, Visa, credit limit, minimum payment, payment due date
- Credit card/LOC/loan accounts mapped to liabilities in net worth (was incorrectly hardcoded as asset)
- Account names now use full product name (e.g., "RBC Business Cash Back Mastercard") instead of just bank name
- Existing misclassified accounts corrected on next reprocessing
- No schema changes needed — existing fields already support asset/liability distinction

Closes NAN-482

## Test plan
- [ ] Upload a credit card statement → account classified as liability
- [ ] Net worth shows credit card balance under Liabilities section
- [ ] Net worth = total assets - total liabilities (credit card subtracts)
- [ ] Reprocess existing credit card statement → account reclassified
- [ ] Regular chequing/savings accounts still classified as assets
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)