### PR TITLE
feat: add Exa web research tool for AI advisor (NAN-472)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ OPENAI_API_KEY="sk-..."
 # OpenRouter (for fast AI chat via Cerebras, Gemini, and other models)
 OPENROUTER_API_KEY=""
 
+# Exa (for AI web research — current tax rates, interest rates, financial regulations)
+# Optional: get a key at https://exa.ai
+EXA_API_KEY=""
+
 # BetterAuth
 BETTER_AUTH_SECRET=""
 BETTER_AUTH_URL="http://localhost:3000"

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -69,6 +69,7 @@ The simplest way to deploy OpenFinance is with Docker Compose.
 | `BETTER_AUTH_SECRET` | Yes | Secret key for session encryption. Generate with `openssl rand -base64 32`. |
 | `BETTER_AUTH_URL` | Yes | Public URL of your instance (e.g., `https://finance.yourdomain.com`). |
 | `OPENROUTER_API_KEY` | Yes | OpenRouter API key for AI statement processing and chat. |
+| `EXA_API_KEY` | No | Exa API key for AI web research (current tax rates, interest rates, regulations). Get one at [exa.ai](https://exa.ai). |
 | `GOOGLE_CLIENT_ID` | No | Google OAuth client ID for "Sign in with Google". |
 | `GOOGLE_CLIENT_SECRET` | No | Google OAuth client secret. |
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^4.1.0",
+    "exa-js": "^2.4.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.400.0",
     "mathjs": "^15.1.1",

--- a/src/lib/chat/system-prompt.ts
+++ b/src/lib/chat/system-prompt.ts
@@ -42,6 +42,25 @@ Today is ${today}. Use this to interpret relative date references like "last mon
 - **list_scenarios**: List the user's saved scenarios with summary data
 - **compare_scenarios**: Compare 2-3 saved scenarios side by side for the user to visualize
 - **delete_scenario**: Delete a saved scenario
+- **search_web**: Search the web for current financial information (tax rates, TFSA/RRSP limits, interest rates, regulations, stock/ETF info). Returns real-time results from trusted sources.
+
+## Web Research Guidelines
+Use search_web when the user asks about:
+- **Current rates & limits**: Tax brackets, TFSA/RRSP contribution limits, CRA rules, interest rates, mortgage rates, GIC rates — these change yearly
+- **Market information**: Stock/ETF prices, fund details, index performance
+- **Regulations & policy**: Financial regulations, government policy changes, new tax rules
+- **Comparisons & strategies**: Investment products, financial institution offerings, account comparisons
+
+Do NOT use search_web when:
+- The question can be answered from the user's own transaction data (use search_transactions, get_cashflow, etc.)
+- You are confident the information hasn't changed since your training data (basic financial concepts, general advice)
+- The user asks about their personal finances (use their data tools and memories instead)
+
+When presenting web research results:
+- Cite your sources with titles and URLs so the user can verify
+- Note the publish date if available to indicate freshness
+- Synthesize the information into a clear answer rather than just listing results
+- If results conflict, mention the discrepancy and recommend the most authoritative source
 
 ## Memory Guidelines — CRITICAL
 Your memory system is your most important feature for providing a personalized experience. Follow these rules strictly:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,6 +3695,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:~4.1.0":
+  version: 4.1.0
+  resolution: "cross-fetch@npm:4.1.0"
+  dependencies:
+    node-fetch: "npm:^2.7.0"
+  checksum: 628b134ea27cfcada67025afe6ef1419813fffc5d63d175553efa75a2334522d450300a0f3f0719029700da80e96327930709d5551cf6deb39bb62f1d536642e
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -4002,6 +4011,13 @@ __metadata:
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:~16.4.7":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
   languageName: node
   linkType: hard
 
@@ -4564,6 +4580,19 @@ __metadata:
   version: 3.0.6
   resolution: "eventsource-parser@npm:3.0.6"
   checksum: 70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
+  languageName: node
+  linkType: hard
+
+"exa-js@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "exa-js@npm:2.4.0"
+  dependencies:
+    cross-fetch: "npm:~4.1.0"
+    dotenv: "npm:~16.4.7"
+    openai: "npm:^5.0.1"
+    zod: "npm:^3.22.0"
+    zod-to-json-schema: "npm:^3.20.0"
+  checksum: d38aa9315edd645722053e7567dc09aaa7ad755c8f9d86348bcc61ac161ce604b854d17b97d7f9a80471e1f4254f09d83b6284736be35393933a54c7fc3caa90
   languageName: node
   linkType: hard
 
@@ -6333,6 +6362,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 12.2.0
   resolution: "node-gyp@npm:12.2.0"
@@ -6482,6 +6525,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openai@npm:^5.0.1":
+  version: 5.23.2
+  resolution: "openai@npm:5.23.2"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: 8ee37f37c64fd04a61622c4782d231e8f0245e2d85956d833e43d30946edbf07d5276cd74e09aa5d23006de8da43dad312246a9dd7ca6ca6d65d983fc976ffa6
+  languageName: node
+  linkType: hard
+
 "openai@npm:^6.22.0":
   version: 6.22.0
   resolution: "openai@npm:6.22.0"
@@ -6539,6 +6599,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     eslint: "npm:^9.0.0"
     eslint-config-next: "npm:^16.2.0-canary.56"
+    exa-js: "npm:^2.4.0"
     jszip: "npm:^3.10.1"
     lucide-react: "npm:^0.400.0"
     mathjs: "npm:^15.1.1"
@@ -8017,6 +8078,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^2.4.0":
   version: 2.4.0
   resolution: "ts-api-utils@npm:2.4.0"
@@ -8373,6 +8441,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
+  languageName: node
+  linkType: hard
+
 "which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
@@ -8515,12 +8600,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.20.0":
+  version: 3.25.1
+  resolution: "zod-to-json-schema@npm:3.25.1"
+  peerDependencies:
+    zod: ^3.25 || ^4
+  checksum: 711b30e34d1f1211f1afe64bf457f0d799234199dc005cca720b236ea808804c03164039c232f5df33c46f462023874015a8a0b3aab1585eca14124c324db7e2
+  languageName: node
+  linkType: hard
+
 "zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
   peerDependencies:
     zod: ^3.25.0 || ^4.0.0
   checksum: 0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.0":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add `search_web` tool using Exa AI search SDK for real-time financial information retrieval
- AI advisor can now research current tax rates, TFSA/RRSP limits, interest rates, stock/ETF info, and financial regulations
- Search results render inline in chat with collapsible source links (title, domain, publish date)
- System prompt updated with guidelines on when to use web research vs cached knowledge
- Graceful fallback when `EXA_API_KEY` is not configured

## Test plan
- [ ] Set `EXA_API_KEY` in `.env` and verify search_web tool works (ask AI "What are the 2026 TFSA contribution limits?")
- [ ] Verify search results render nicely with clickable source links
- [ ] Verify collapsible "Show N more sources" toggle works
- [ ] Without `EXA_API_KEY`, verify AI gets a helpful error message and doesn't crash
- [ ] Verify AI uses user data tools (not web search) for personal finance questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)