### PR TITLE
feat: allow renaming chat threads (NAN-464)

### DIFF
--- a/src/app/api/chat/threads/[threadId]/route.ts
+++ b/src/app/api/chat/threads/[threadId]/route.ts
@@ -1,0 +1,37 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+import { NextRequest } from 'next/server'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ threadId: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+  }
+
+  const { threadId } = await params
+  const body = await request.json()
+  const { title } = body as { title?: string }
+
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    return new Response(JSON.stringify({ error: 'Title is required' }), { status: 400 })
+  }
+
+  const thread = await prisma.chatThread.findFirst({
+    where: { id: threadId, userId: session.user.id },
+  })
+
+  if (!thread) {
+    return new Response(JSON.stringify({ error: 'Thread not found' }), { status: 404 })
+  }
+
+  const updated = await prisma.chatThread.update({
+    where: { id: threadId },
+    data: { title: title.trim() },
+  })
+
+  return Response.json({ id: updated.id, title: updated.title })
+}


### PR DESCRIPTION
## Summary
- Add `PATCH /api/chat/threads/:threadId` endpoint with auth + ownership check
- Thread sidebar shows three-dot context menu on hover with "Rename" option
- Double-click on thread title also enters inline edit mode
- Save on Enter/blur, cancel on Escape
- Optimistic UI updates with revert on API failure

## Test plan
- [ ] Hover over a thread in sidebar → three-dot menu appears
- [ ] Click three-dot → "Rename" option → inline input appears with title selected
- [ ] Edit title, press Enter → title updates immediately
- [ ] Edit title, press Escape → reverts to original
- [ ] Double-click thread title → inline edit mode activates
- [ ] Verify rename persists after page refresh
- [ ] Verify other users cannot rename threads they don't own (401/404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)