### PR TITLE
feat: Google Drive inline import wizard (NAN-461)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,7 @@ const nextConfig: NextConfig = {
     '@opentelemetry/sdk-trace-base',
     '@langfuse/otel',
     '@langfuse/tracing',
+    'googleapis',
   ],
 }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "clsx": "^2.1.0",
     "date-fns": "^4.1.0",
     "exa-js": "^2.4.0",
+    "googleapis": "^171.4.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.400.0",
     "mathjs": "^15.1.1",

--- a/src/app/api/google-drive/callback/route.ts
+++ b/src/app/api/google-drive/callback/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { handleGoogleDriveCallback } from '@/lib/google-drive'
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.redirect(new URL('/auth/login', request.url))
+  }
+
+  const code = request.nextUrl.searchParams.get('code')
+  const state = request.nextUrl.searchParams.get('state')
+
+  if (!code) {
+    return NextResponse.redirect(
+      new URL('/documents?error=google_drive_no_code', request.url),
+    )
+  }
+
+  // Verify the state parameter matches the authenticated user
+  if (state !== session.user.id) {
+    return NextResponse.redirect(
+      new URL('/documents?error=google_drive_state_mismatch', request.url),
+    )
+  }
+
+  try {
+    await handleGoogleDriveCallback(code, session.user.id)
+    return NextResponse.redirect(
+      new URL('/documents?google_drive=connected', request.url),
+    )
+  } catch (error) {
+    console.error('Google Drive callback error:', error)
+    return NextResponse.redirect(
+      new URL('/documents?error=google_drive_connect_failed', request.url),
+    )
+  }
+}

--- a/src/app/api/google-drive/connect/route.ts
+++ b/src/app/api/google-drive/connect/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { getGoogleDriveAuthUrl } from '@/lib/google-drive'
+
+export async function POST() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const url = getGoogleDriveAuthUrl(session.user.id)
+    return NextResponse.json({ url })
+  } catch (error) {
+    console.error('Google Drive connect error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to generate auth URL' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/google-drive/disconnect/route.ts
+++ b/src/app/api/google-drive/disconnect/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { disconnectGoogleDrive } from '@/lib/google-drive'
+
+export async function POST() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    await disconnectGoogleDrive(session.user.id)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Google Drive disconnect error:', error)
+    return NextResponse.json(
+      { error: 'Failed to disconnect' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/google-drive/files/route.ts
+++ b/src/app/api/google-drive/files/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { listDriveFiles } from '@/lib/google-drive'
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const folderId = request.nextUrl.searchParams.get('folderId')
+  if (!folderId) {
+    return NextResponse.json(
+      { error: 'folderId is required' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const files = await listDriveFiles(session.user.id, folderId)
+    return NextResponse.json({ files })
+  } catch (error) {
+    console.error('Google Drive files error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to list files' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/google-drive/folders/route.ts
+++ b/src/app/api/google-drive/folders/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { listDriveFolders } from '@/lib/google-drive'
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const parentId = request.nextUrl.searchParams.get('parentId') ?? undefined
+
+  try {
+    const folders = await listDriveFolders(session.user.id, parentId)
+    return NextResponse.json({ folders })
+  } catch (error) {
+    console.error('Google Drive folders error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to list folders' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/google-drive/import/route.ts
+++ b/src/app/api/google-drive/import/route.ts
@@ -1,0 +1,191 @@
+import { createHash } from 'crypto'
+import { writeFile } from 'fs/promises'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { downloadDriveFile } from '@/lib/google-drive'
+import { classifyByFilename } from '@/lib/services/document-classifier'
+import { prepareUpload } from '@/lib/upload-path'
+import { prisma } from '@/lib/prisma'
+
+interface ImportFileRequest {
+  fileId: string
+  fileName: string
+  mimeType: string
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json() as { files: ImportFileRequest[] }
+  const { files } = body
+
+  if (!files || !Array.isArray(files) || files.length === 0) {
+    return NextResponse.json(
+      { error: 'No files specified' },
+      { status: 400 },
+    )
+  }
+
+  if (files.length > 20) {
+    return NextResponse.json(
+      { error: 'Maximum 20 files per import' },
+      { status: 400 },
+    )
+  }
+
+  const results: Array<{
+    fileId: string
+    fileName: string
+    success: boolean
+    error?: string
+    statementId?: string
+    documentId?: string
+  }> = []
+
+  for (const file of files) {
+    try {
+      // Check if this file was already imported
+      const existing = await prisma.document.findFirst({
+        where: {
+          userId: session.user.id,
+          googleDriveFileId: file.fileId,
+        },
+      })
+      if (existing) {
+        results.push({
+          fileId: file.fileId,
+          fileName: file.fileName,
+          success: false,
+          error: 'Already imported',
+        })
+        continue
+      }
+
+      // Download from Google Drive
+      const buffer = await downloadDriveFile(session.user.id, file.fileId)
+      const contentHash = createHash('sha256').update(buffer).digest('hex')
+
+      // Classify by filename
+      const documentType = classifyByFilename(file.fileName) ?? 'other'
+      const isPdf = file.mimeType === 'application/pdf' ||
+        file.fileName.toLowerCase().endsWith('.pdf')
+      const isStatement = documentType === 'statement' && isPdf
+
+      // Prepare upload path
+      const { relPath, fullPath, sanitizedFileName } = await prepareUpload(
+        session.user.id,
+        file.fileName,
+      )
+      await writeFile(fullPath, buffer)
+
+      if (isStatement) {
+        // Check for duplicate statement by content hash
+        const existingStatement = await prisma.bankStatement.findFirst({
+          where: { userId: session.user.id, contentHash },
+        })
+        if (existingStatement) {
+          results.push({
+            fileId: file.fileId,
+            fileName: file.fileName,
+            success: false,
+            error: 'Duplicate statement',
+          })
+          continue
+        }
+
+        const statement = await prisma.bankStatement.create({
+          data: {
+            userId: session.user.id,
+            fileName: sanitizedFileName,
+            fileUrl: relPath,
+            fileSize: buffer.length,
+            contentHash,
+            bankName: 'Unknown',
+            status: 'pending',
+          },
+        })
+
+        // Also create a Document record to track the Google Drive file ID
+        await prisma.document.create({
+          data: {
+            userId: session.user.id,
+            fileName: sanitizedFileName,
+            fileUrl: relPath,
+            fileSize: buffer.length,
+            mimeType: file.mimeType || 'application/pdf',
+            documentType: 'statement',
+            contentHash,
+            googleDriveFileId: file.fileId,
+          },
+        })
+
+        results.push({
+          fileId: file.fileId,
+          fileName: file.fileName,
+          success: true,
+          statementId: statement.id,
+        })
+      } else {
+        // Check for duplicate document by content hash
+        const existingDoc = await prisma.document.findFirst({
+          where: { userId: session.user.id, contentHash },
+        })
+        if (existingDoc) {
+          results.push({
+            fileId: file.fileId,
+            fileName: file.fileName,
+            success: false,
+            error: 'Duplicate file',
+          })
+          continue
+        }
+
+        const document = await prisma.document.create({
+          data: {
+            userId: session.user.id,
+            fileName: sanitizedFileName,
+            fileUrl: relPath,
+            fileSize: buffer.length,
+            mimeType: file.mimeType || 'application/octet-stream',
+            documentType,
+            contentHash,
+            googleDriveFileId: file.fileId,
+          },
+        })
+
+        results.push({
+          fileId: file.fileId,
+          fileName: file.fileName,
+          success: true,
+          documentId: document.id,
+        })
+      }
+    } catch (error) {
+      console.error(`Failed to import ${file.fileName}:`, error)
+      results.push({
+        fileId: file.fileId,
+        fileName: file.fileName,
+        success: false,
+        error: error instanceof Error ? error.message : 'Import failed',
+      })
+    }
+  }
+
+  const successCount = results.filter(r => r.success).length
+  const statementIds = results
+    .filter(r => r.success && r.statementId)
+    .map(r => r.statementId!)
+
+  return NextResponse.json({
+    results,
+    successCount,
+    totalCount: files.length,
+    statementIds,
+  })
+}

--- a/src/app/api/google-drive/status/route.ts
+++ b/src/app/api/google-drive/status/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+import { auth } from '@/lib/auth'
+import { getGoogleDriveStatus } from '@/lib/google-drive'
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const status = await getGoogleDriveStatus(session.user.id)
+    return NextResponse.json(status)
+  } catch (error) {
+    console.error('Google Drive status error:', error)
+    return NextResponse.json(
+      { error: 'Failed to check status' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/documents/document-uploader.tsx
+++ b/src/components/documents/document-uploader.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { GoogleDriveImportWizard } from './google-drive-import-wizard'
 import { showJobProgressToast } from '@/lib/jobs/job-toast'
 
 import '@uppy/core/css/style.min.css'
@@ -49,6 +50,7 @@ interface DocumentUploadZoneProps {
 export function DocumentUploadZone({ children }: DocumentUploadZoneProps) {
   const router = useRouter()
   const [modalOpen, setModalOpen] = useState(false)
+  const [driveWizardOpen, setDriveWizardOpen] = useState(false)
   const [dragOver, setDragOver] = useState(false)
   const [trackedFiles, setTrackedFiles] = useState<TrackedFile[]>([])
   const [indicatorExpanded, setIndicatorExpanded] = useState(false)
@@ -261,10 +263,6 @@ export function DocumentUploadZone({ children }: DocumentUploadZoneProps) {
     setModalOpen(true)
   }
 
-  function handleImportFromGoogleDrive() {
-    toast.info('Google Drive import coming soon')
-  }
-
   // ---- Computed state ----
   const showIndicator = trackedFiles.length > 0
   const inProgressCount = trackedFiles.filter(f =>
@@ -313,7 +311,7 @@ export function DocumentUploadZone({ children }: DocumentUploadZoneProps) {
               <FileUp className="h-4 w-4" />
               Import from File
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleImportFromGoogleDrive}>
+            <DropdownMenuItem onClick={() => setDriveWizardOpen(true)}>
               <HardDrive className="h-4 w-4" />
               Import from Google Drive
             </DropdownMenuItem>
@@ -337,6 +335,12 @@ export function DocumentUploadZone({ children }: DocumentUploadZoneProps) {
           uppy.clear()
           setModalOpen(false)
         }}
+      />
+
+      {/* Google Drive import wizard */}
+      <GoogleDriveImportWizard
+        open={driveWizardOpen}
+        onOpenChange={setDriveWizardOpen}
       />
 
       {/* Floating upload indicator */}

--- a/src/components/documents/google-drive-import-wizard.tsx
+++ b/src/components/documents/google-drive-import-wizard.tsx
@@ -1,0 +1,792 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Loader2,
+  FolderOpen,
+  FileText,
+  ChevronRight,
+  ArrowLeft,
+  Check,
+  AlertCircle,
+  HardDrive,
+  Unplug,
+} from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { formatFileSize } from './document-types'
+import { showJobProgressToast } from '@/lib/jobs/job-toast'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type WizardStep = 'connect' | 'browse' | 'files' | 'importing'
+
+interface DriveFolder {
+  id: string
+  name: string
+}
+
+interface DriveFile {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+  modifiedTime: string
+}
+
+interface ConnectionStatus {
+  connected: boolean
+  email?: string | null
+}
+
+interface ImportResult {
+  fileId: string
+  fileName: string
+  success: boolean
+  error?: string
+  statementId?: string
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface GoogleDriveImportWizardProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function GoogleDriveImportWizard({ open, onOpenChange }: GoogleDriveImportWizardProps) {
+  const router = useRouter()
+
+  // Connection state
+  const [status, setStatus] = useState<ConnectionStatus | null>(null)
+  const [connecting, setConnecting] = useState(false)
+  const [checkingStatus, setCheckingStatus] = useState(false)
+
+  // Explicit step tracking
+  const [currentStep, setCurrentStep] = useState<WizardStep>('connect')
+
+  // Folder navigation state
+  const [folders, setFolders] = useState<DriveFolder[]>([])
+  const [folderStack, setFolderStack] = useState<Array<{ id: string; name: string }>>([])
+  const [loadingFolders, setLoadingFolders] = useState(false)
+
+  // File selection state
+  const [files, setFiles] = useState<DriveFile[]>([])
+  const [selectedFileIds, setSelectedFileIds] = useState<Set<string>>(new Set())
+  const [loadingFiles, setLoadingFiles] = useState(false)
+
+  // Import state
+  const [importing, setImporting] = useState(false)
+  const [importResults, setImportResults] = useState<ImportResult[]>([])
+
+  // ---------------------------------------------------------------------------
+  // Check connection status when modal opens
+  // ---------------------------------------------------------------------------
+
+  const checkStatus = useCallback(async () => {
+    setCheckingStatus(true)
+    try {
+      const res = await fetch('/api/google-drive/status')
+      const data = await res.json()
+      setStatus(data)
+      // Set initial step based on connection status
+      if (data.connected) {
+        setCurrentStep('browse')
+      } else {
+        setCurrentStep('connect')
+      }
+    } catch {
+      setStatus({ connected: false })
+      setCurrentStep('connect')
+    } finally {
+      setCheckingStatus(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) {
+      // Reset all state when opening
+      setFolders([])
+      setFolderStack([])
+      setFiles([])
+      setSelectedFileIds(new Set())
+      setImportResults([])
+      setImporting(false)
+      checkStatus()
+    }
+  }, [open, checkStatus])
+
+  // Load root folders when entering browse step
+  useEffect(() => {
+    if (currentStep === 'browse' && status?.connected && folders.length === 0 && !loadingFolders && open) {
+      loadFolders()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentStep, status?.connected, open])
+
+  // ---------------------------------------------------------------------------
+  // OAuth connect flow
+  // ---------------------------------------------------------------------------
+
+  async function handleConnect() {
+    setConnecting(true)
+    try {
+      const res = await fetch('/api/google-drive/connect', { method: 'POST' })
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to start connection')
+        setConnecting(false)
+        return
+      }
+
+      // Open OAuth in a popup window
+      const popup = window.open(
+        data.url,
+        'google-drive-connect',
+        'width=600,height=700,popup=yes',
+      )
+
+      // Poll for popup close (OAuth completed or cancelled)
+      const pollInterval = setInterval(async () => {
+        if (!popup || popup.closed) {
+          clearInterval(pollInterval)
+          setConnecting(false)
+          // Recheck status after OAuth flow completes
+          await checkStatus()
+        }
+      }, 500)
+    } catch {
+      toast.error('Failed to connect Google Drive')
+      setConnecting(false)
+    }
+  }
+
+  async function handleDisconnect() {
+    try {
+      await fetch('/api/google-drive/disconnect', { method: 'POST' })
+      setStatus({ connected: false })
+      setCurrentStep('connect')
+      setFolders([])
+      setFolderStack([])
+      setFiles([])
+      setSelectedFileIds(new Set())
+      toast.success('Google Drive disconnected')
+    } catch {
+      toast.error('Failed to disconnect')
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Folder navigation
+  // ---------------------------------------------------------------------------
+
+  async function loadFolders(parentId?: string) {
+    setLoadingFolders(true)
+    try {
+      const params = parentId ? `?parentId=${parentId}` : ''
+      const res = await fetch(`/api/google-drive/folders${params}`)
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to load folders')
+        return
+      }
+
+      setFolders(data.folders)
+    } catch {
+      toast.error('Failed to load folders')
+    } finally {
+      setLoadingFolders(false)
+    }
+  }
+
+  function handleFolderClick(folder: DriveFolder) {
+    setFolderStack(prev => [...prev, folder])
+    setFolders([])
+    loadFolders(folder.id)
+    // Also pre-load files for this folder
+    loadFiles(folder.id)
+  }
+
+  function handleFolderBack() {
+    const newStack = [...folderStack]
+    newStack.pop()
+    setFolderStack(newStack)
+    setFiles([])
+    setSelectedFileIds(new Set())
+
+    const parentId = newStack.length > 0
+      ? newStack[newStack.length - 1].id
+      : undefined
+    loadFolders(parentId)
+  }
+
+  function handleSelectFilesFromFolder() {
+    setCurrentStep('files')
+  }
+
+  // ---------------------------------------------------------------------------
+  // File listing & selection
+  // ---------------------------------------------------------------------------
+
+  async function loadFiles(folderId: string) {
+    setLoadingFiles(true)
+    try {
+      const res = await fetch(`/api/google-drive/files?folderId=${folderId}`)
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to load files')
+        return
+      }
+
+      setFiles(data.files)
+    } catch {
+      toast.error('Failed to load files')
+    } finally {
+      setLoadingFiles(false)
+    }
+  }
+
+  function handleToggleFile(fileId: string) {
+    setSelectedFileIds(prev => {
+      const next = new Set(prev)
+      if (next.has(fileId)) {
+        next.delete(fileId)
+      } else {
+        next.add(fileId)
+      }
+      return next
+    })
+  }
+
+  function handleToggleAllFiles() {
+    if (selectedFileIds.size === files.length) {
+      setSelectedFileIds(new Set())
+    } else {
+      setSelectedFileIds(new Set(files.map(f => f.id)))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Import
+  // ---------------------------------------------------------------------------
+
+  async function handleImport() {
+    const selectedFiles = files.filter(f => selectedFileIds.has(f.id))
+    if (selectedFiles.length === 0) return
+
+    setCurrentStep('importing')
+    setImporting(true)
+    setImportResults([])
+
+    try {
+      const res = await fetch('/api/google-drive/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          files: selectedFiles.map(f => ({
+            fileId: f.id,
+            fileName: f.name,
+            mimeType: f.mimeType,
+          })),
+        }),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error || 'Import failed')
+        setImporting(false)
+        return
+      }
+
+      setImportResults(data.results)
+
+      const successCount = data.successCount as number
+      const totalCount = data.totalCount as number
+
+      if (successCount === totalCount) {
+        toast.success(`Imported ${successCount} file${successCount !== 1 ? 's' : ''}`)
+      } else if (successCount > 0) {
+        toast.warning(`Imported ${successCount} of ${totalCount} files`)
+      } else {
+        toast.error('No files were imported')
+      }
+
+      // If any statements were created, trigger processing
+      const statementIds = data.statementIds as string[]
+      if (statementIds.length === 1) {
+        const stmtResult = data.results.find(
+          (r: ImportResult) => r.statementId === statementIds[0],
+        )
+        if (stmtResult) {
+          toast.info('Processing imported statement...', {
+            description: stmtResult.fileName,
+          })
+          fetch('/api/process-statement', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ statementId: statementIds[0] }),
+          }).then(() => router.refresh())
+        }
+      } else if (statementIds.length > 1) {
+        try {
+          const bulkRes = await fetch('/api/statements/process-bulk', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              files: data.results
+                .filter((r: ImportResult) => r.statementId)
+                .map((r: ImportResult) => ({ statementId: r.statementId })),
+            }),
+          })
+          const bulkData = await bulkRes.json()
+          if (bulkRes.ok && bulkData.jobId) {
+            showJobProgressToast(bulkData.jobId, statementIds.length)
+          }
+        } catch {
+          // Bulk processing is optional -- files were still imported
+        }
+      }
+
+      router.refresh()
+    } catch {
+      toast.error('Import failed')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Breadcrumb for current folder path
+  // ---------------------------------------------------------------------------
+
+  function renderBreadcrumbs() {
+    return (
+      <div className="flex items-center gap-1 text-sm text-gray-500">
+        <button
+          onClick={() => {
+            setFolderStack([])
+            setFiles([])
+            setSelectedFileIds(new Set())
+            setCurrentStep('browse')
+            loadFolders()
+          }}
+          className="hover:text-gray-900"
+        >
+          My Drive
+        </button>
+        {folderStack.map((folder, i) => (
+          <span key={folder.id} className="flex items-center gap-1">
+            <ChevronRight className="h-3 w-3" />
+            <button
+              onClick={() => {
+                const newStack = folderStack.slice(0, i + 1)
+                setFolderStack(newStack)
+                setFiles([])
+                setSelectedFileIds(new Set())
+                setCurrentStep('browse')
+                loadFolders(folder.id)
+                loadFiles(folder.id)
+              }}
+              className="hover:text-gray-900"
+            >
+              {folder.name}
+            </button>
+          </span>
+        ))}
+      </div>
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step indicator
+  // ---------------------------------------------------------------------------
+
+  function renderStepIndicator() {
+    const steps: Array<{ key: WizardStep; label: string }> = [
+      { key: 'connect', label: 'Connect' },
+      { key: 'browse', label: 'Browse' },
+      { key: 'files', label: 'Select' },
+      { key: 'importing', label: 'Import' },
+    ]
+
+    const currentIdx = steps.findIndex(s => s.key === currentStep)
+
+    return (
+      <div className="flex items-center gap-2">
+        {steps.map((s, i) => (
+          <div key={s.key} className="flex items-center gap-2">
+            <div
+              className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${
+                i < currentIdx
+                  ? 'bg-violet-600 text-white'
+                  : i === currentIdx
+                    ? 'bg-violet-100 text-violet-700 ring-2 ring-violet-600'
+                    : 'bg-gray-100 text-gray-400'
+              }`}
+            >
+              {i < currentIdx ? <Check className="h-3 w-3" /> : i + 1}
+            </div>
+            <span
+              className={`text-xs ${
+                i === currentIdx ? 'font-medium text-gray-900' : 'text-gray-400'
+              }`}
+            >
+              {s.label}
+            </span>
+            {i < steps.length - 1 && (
+              <div className={`h-px w-6 ${i < currentIdx ? 'bg-violet-600' : 'bg-gray-200'}`} />
+            )}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step descriptions
+  // ---------------------------------------------------------------------------
+
+  const stepDescriptions: Record<WizardStep, string> = {
+    connect: 'Connect your Google Drive to import documents.',
+    browse: 'Browse your Google Drive folders to find files.',
+    files: 'Select files to import into OpenFinance.',
+    importing: 'Importing your selected files...',
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <HardDrive className="h-5 w-5 text-violet-600" />
+            Import from Google Drive
+          </DialogTitle>
+          <DialogDescription>
+            {stepDescriptions[currentStep]}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Step indicator */}
+        <div className="border-b border-gray-100 pb-3">
+          {renderStepIndicator()}
+        </div>
+
+        {/* Loading initial status */}
+        {checkingStatus && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-violet-600" />
+          </div>
+        )}
+
+        {/* Step 1: Connect */}
+        {!checkingStatus && currentStep === 'connect' && (
+          <div className="flex flex-col items-center gap-6 py-8">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-violet-50">
+              <HardDrive className="h-8 w-8 text-violet-600" />
+            </div>
+            <div className="text-center">
+              <h3 className="text-lg font-medium text-gray-900">Connect your Google Drive</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                OpenFinance needs read-only access to browse and import your files.
+              </p>
+            </div>
+            <Button
+              onClick={handleConnect}
+              disabled={connecting}
+              size="lg"
+              className="gap-2"
+            >
+              {connecting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Connecting...
+                </>
+              ) : (
+                <>
+                  <HardDrive className="h-4 w-4" />
+                  Connect Google Drive
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+
+        {/* Step 2: Browse folders */}
+        {!checkingStatus && currentStep === 'browse' && (
+          <div className="space-y-3">
+            {/* Connected account info */}
+            {status?.email && (
+              <div className="flex items-center justify-between rounded-lg bg-green-50 px-3 py-2 text-sm">
+                <span className="text-green-700">
+                  Connected as <span className="font-medium">{status.email}</span>
+                </span>
+                <button
+                  onClick={handleDisconnect}
+                  className="flex items-center gap-1 text-xs text-gray-500 hover:text-red-600"
+                >
+                  <Unplug className="h-3 w-3" />
+                  Disconnect
+                </button>
+              </div>
+            )}
+
+            {/* Breadcrumbs */}
+            {renderBreadcrumbs()}
+
+            {/* Back button when inside a subfolder */}
+            {folderStack.length > 0 && (
+              <button
+                onClick={handleFolderBack}
+                className="flex items-center gap-1 text-sm text-violet-600 hover:text-violet-800"
+              >
+                <ArrowLeft className="h-3 w-3" />
+                Back
+              </button>
+            )}
+
+            {/* Folder list */}
+            {loadingFolders ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-violet-600" />
+              </div>
+            ) : folders.length === 0 && folderStack.length === 0 ? (
+              <div className="py-8 text-center text-sm text-gray-500">
+                No folders found in your Google Drive root.
+              </div>
+            ) : (
+              <>
+                {folders.length > 0 && (
+                  <div className="max-h-48 overflow-y-auto rounded-lg border border-gray-200">
+                    {folders.map(folder => (
+                      <button
+                        key={folder.id}
+                        onClick={() => handleFolderClick(folder)}
+                        className="flex w-full items-center gap-3 border-b border-gray-100 px-4 py-3 text-left last:border-0 hover:bg-gray-50"
+                      >
+                        <FolderOpen className="h-5 w-5 shrink-0 text-violet-500" />
+                        <span className="truncate text-sm font-medium text-gray-900">
+                          {folder.name}
+                        </span>
+                        <ChevronRight className="ml-auto h-4 w-4 shrink-0 text-gray-400" />
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {folders.length === 0 && folderStack.length > 0 && (
+                  <div className="py-4 text-center text-sm text-gray-500">
+                    No subfolders in this folder.
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* File preview for current folder */}
+            {folderStack.length > 0 && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-medium text-gray-700">
+                    Files in {folderStack[folderStack.length - 1].name}
+                  </h4>
+                  {!loadingFiles && files.length > 0 && (
+                    <Button
+                      size="sm"
+                      onClick={handleSelectFilesFromFolder}
+                    >
+                      Select files ({files.length})
+                    </Button>
+                  )}
+                </div>
+                {loadingFiles ? (
+                  <div className="flex items-center justify-center py-4">
+                    <Loader2 className="h-4 w-4 animate-spin text-violet-600" />
+                  </div>
+                ) : files.length === 0 ? (
+                  <p className="text-xs text-gray-500">
+                    No importable files in this folder.
+                  </p>
+                ) : (
+                  <p className="text-xs text-gray-500">
+                    {files.length} importable file{files.length !== 1 ? 's' : ''} found.
+                    Click &quot;Select files&quot; to choose which to import.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Step 3: Select files */}
+        {!checkingStatus && currentStep === 'files' && (
+          <div className="space-y-3">
+            {/* Breadcrumbs */}
+            {renderBreadcrumbs()}
+
+            {/* Back to folder browser */}
+            <button
+              onClick={() => {
+                setSelectedFileIds(new Set())
+                setCurrentStep('browse')
+              }}
+              className="flex items-center gap-1 text-sm text-violet-600 hover:text-violet-800"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              Back to folders
+            </button>
+
+            {/* Loading files */}
+            {loadingFiles ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-violet-600" />
+              </div>
+            ) : files.length === 0 ? (
+              <div className="py-8 text-center text-sm text-gray-500">
+                No importable files found in this folder.
+                <br />
+                Supported formats: PDF, CSV, TXT, Markdown, Images, Excel
+              </div>
+            ) : (
+              <>
+                {/* Select all / count */}
+                <div className="flex items-center justify-between">
+                  <label className="flex items-center gap-2 text-sm text-gray-700">
+                    <input
+                      type="checkbox"
+                      checked={selectedFileIds.size === files.length && files.length > 0}
+                      ref={el => {
+                        if (el) el.indeterminate = selectedFileIds.size > 0 && selectedFileIds.size < files.length
+                      }}
+                      onChange={handleToggleAllFiles}
+                      className="h-4 w-4 rounded border-gray-300 text-violet-600 focus:ring-violet-500"
+                    />
+                    Select all ({files.length} file{files.length !== 1 ? 's' : ''})
+                  </label>
+                  {selectedFileIds.size > 0 && (
+                    <span className="text-sm font-medium text-violet-600">
+                      {selectedFileIds.size} selected
+                    </span>
+                  )}
+                </div>
+
+                {/* File list */}
+                <div className="max-h-64 overflow-y-auto rounded-lg border border-gray-200">
+                  {files.map(file => (
+                    <label
+                      key={file.id}
+                      className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-4 py-3 last:border-0 hover:bg-gray-50"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedFileIds.has(file.id)}
+                        onChange={() => handleToggleFile(file.id)}
+                        className="h-4 w-4 shrink-0 rounded border-gray-300 text-violet-600 focus:ring-violet-500"
+                      />
+                      <FileText className="h-5 w-5 shrink-0 text-gray-400" />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-gray-900">
+                          {file.name}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {formatFileSize(file.size)}
+                          {' -- '}
+                          {new Date(file.modifiedTime).toLocaleDateString()}
+                        </p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+
+                {/* Import button */}
+                <div className="flex justify-end pt-2">
+                  <Button
+                    onClick={handleImport}
+                    disabled={selectedFileIds.size === 0}
+                    className="gap-2"
+                  >
+                    Import {selectedFileIds.size} file{selectedFileIds.size !== 1 ? 's' : ''}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Step 4: Import progress / results */}
+        {!checkingStatus && currentStep === 'importing' && (
+          <div className="space-y-4 py-4">
+            {importing && (
+              <div className="flex flex-col items-center gap-4 py-6">
+                <Loader2 className="h-8 w-8 animate-spin text-violet-600" />
+                <p className="text-sm font-medium text-gray-700">
+                  Importing files from Google Drive...
+                </p>
+              </div>
+            )}
+
+            {!importing && importResults.length > 0 && (
+              <>
+                <div className="rounded-lg border border-gray-200">
+                  {importResults.map(result => (
+                    <div
+                      key={result.fileId}
+                      className="flex items-center gap-3 border-b border-gray-100 px-4 py-3 last:border-0"
+                    >
+                      {result.success ? (
+                        <Check className="h-4 w-4 shrink-0 text-green-600" />
+                      ) : (
+                        <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+                      )}
+                      <span className="truncate text-sm text-gray-900">{result.fileName}</span>
+                      {result.error && (
+                        <span className="ml-auto shrink-0 text-xs text-red-500">{result.error}</span>
+                      )}
+                      {result.success && (
+                        <span className="ml-auto shrink-0 text-xs text-green-600">Imported</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="flex justify-end gap-2 pt-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setImportResults([])
+                      setSelectedFileIds(new Set())
+                      setCurrentStep('browse')
+                    }}
+                  >
+                    Import More
+                  </Button>
+                  <Button onClick={() => onOpenChange(false)}>
+                    Done
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/google-drive.ts
+++ b/src/lib/google-drive.ts
@@ -1,0 +1,235 @@
+import { google } from 'googleapis'
+
+import { encrypt, decrypt } from '@/lib/encryption'
+import { prisma } from '@/lib/prisma'
+
+// ---------------------------------------------------------------------------
+// OAuth2 client factory
+// ---------------------------------------------------------------------------
+
+function getOAuth2Client() {
+  const clientId = process.env.GOOGLE_CLIENT_ID
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET
+  const betterAuthUrl = process.env.BETTER_AUTH_URL || 'http://localhost:3000'
+  const redirectUri = `${betterAuthUrl}/api/google-drive/callback`
+
+  if (!clientId || !clientSecret) {
+    throw new Error('Google OAuth credentials not configured (GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET)')
+  }
+
+  return new google.auth.OAuth2(clientId, clientSecret, redirectUri)
+}
+
+// Scopes needed for read-only Drive access
+const DRIVE_SCOPES = [
+  'https://www.googleapis.com/auth/drive.readonly',
+  'https://www.googleapis.com/auth/userinfo.email',
+]
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the Google OAuth URL for connecting Google Drive.
+ * The `state` parameter carries the userId so the callback can associate the tokens.
+ */
+export function getGoogleDriveAuthUrl(userId: string): string {
+  const oauth2 = getOAuth2Client()
+  return oauth2.generateAuthUrl({
+    access_type: 'offline',
+    prompt: 'consent',
+    scope: DRIVE_SCOPES,
+    state: userId,
+  })
+}
+
+/**
+ * Exchange an authorization code for tokens and persist the connection.
+ */
+export async function handleGoogleDriveCallback(code: string, userId: string) {
+  const oauth2 = getOAuth2Client()
+  const { tokens } = await oauth2.getToken(code)
+
+  if (!tokens.access_token || !tokens.refresh_token || !tokens.expiry_date) {
+    throw new Error('Incomplete token response from Google')
+  }
+
+  // Fetch the user's email for display purposes
+  oauth2.setCredentials(tokens)
+  const oauth2Api = google.oauth2({ version: 'v2', auth: oauth2 })
+  const { data: userInfo } = await oauth2Api.userinfo.get()
+
+  await prisma.googleDriveConnection.upsert({
+    where: { userId },
+    update: {
+      accessToken: encrypt(tokens.access_token),
+      refreshToken: encrypt(tokens.refresh_token),
+      expiresAt: new Date(tokens.expiry_date),
+      email: userInfo.email ?? null,
+    },
+    create: {
+      userId,
+      accessToken: encrypt(tokens.access_token),
+      refreshToken: encrypt(tokens.refresh_token),
+      expiresAt: new Date(tokens.expiry_date),
+      email: userInfo.email ?? null,
+    },
+  })
+
+  return { email: userInfo.email }
+}
+
+/**
+ * Get an authenticated Drive client for a user, refreshing tokens if needed.
+ */
+async function getAuthedDriveClient(userId: string) {
+  const connection = await prisma.googleDriveConnection.findUnique({
+    where: { userId },
+  })
+
+  if (!connection) {
+    throw new Error('Google Drive not connected')
+  }
+
+  const oauth2 = getOAuth2Client()
+  oauth2.setCredentials({
+    access_token: decrypt(connection.accessToken),
+    refresh_token: decrypt(connection.refreshToken),
+    expiry_date: connection.expiresAt.getTime(),
+  })
+
+  // If token is expired or about to expire (within 5 min), refresh it
+  if (connection.expiresAt.getTime() - Date.now() < 5 * 60 * 1000) {
+    const { credentials } = await oauth2.refreshAccessToken()
+    if (credentials.access_token && credentials.expiry_date) {
+      await prisma.googleDriveConnection.update({
+        where: { userId },
+        data: {
+          accessToken: encrypt(credentials.access_token),
+          expiresAt: new Date(credentials.expiry_date),
+        },
+      })
+      oauth2.setCredentials(credentials)
+    }
+  }
+
+  return google.drive({ version: 'v3', auth: oauth2 })
+}
+
+/**
+ * Check connection status for a user.
+ */
+export async function getGoogleDriveStatus(userId: string) {
+  const connection = await prisma.googleDriveConnection.findUnique({
+    where: { userId },
+    select: { email: true, createdAt: true },
+  })
+
+  return connection
+    ? { connected: true as const, email: connection.email, connectedAt: connection.createdAt.toISOString() }
+    : { connected: false as const }
+}
+
+/**
+ * Disconnect Google Drive for a user.
+ */
+export async function disconnectGoogleDrive(userId: string) {
+  await prisma.googleDriveConnection.deleteMany({
+    where: { userId },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Drive file/folder listing
+// ---------------------------------------------------------------------------
+
+export interface DriveFolder {
+  id: string
+  name: string
+}
+
+export interface DriveFile {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+  modifiedTime: string
+}
+
+/**
+ * List folders inside a parent folder (or root if no parent given).
+ */
+export async function listDriveFolders(userId: string, parentId?: string): Promise<DriveFolder[]> {
+  const drive = await getAuthedDriveClient(userId)
+
+  const query = parentId
+    ? `'${parentId}' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false`
+    : `'root' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false`
+
+  const res = await drive.files.list({
+    q: query,
+    fields: 'files(id, name)',
+    orderBy: 'name',
+    pageSize: 100,
+  })
+
+  return (res.data.files ?? []).map(f => ({
+    id: f.id!,
+    name: f.name!,
+  }))
+}
+
+// MIME types we support importing
+const IMPORTABLE_MIMES = new Set([
+  'application/pdf',
+  'text/csv',
+  'text/plain',
+  'text/markdown',
+  'image/jpeg',
+  'image/png',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+])
+
+/**
+ * List importable files inside a folder.
+ */
+export async function listDriveFiles(userId: string, folderId: string): Promise<DriveFile[]> {
+  const drive = await getAuthedDriveClient(userId)
+
+  const mimeFilter = Array.from(IMPORTABLE_MIMES)
+    .map(m => `mimeType = '${m}'`)
+    .join(' or ')
+
+  const query = `'${folderId}' in parents and (${mimeFilter}) and trashed = false`
+
+  const res = await drive.files.list({
+    q: query,
+    fields: 'files(id, name, mimeType, size, modifiedTime)',
+    orderBy: 'modifiedTime desc',
+    pageSize: 200,
+  })
+
+  return (res.data.files ?? []).map(f => ({
+    id: f.id!,
+    name: f.name!,
+    mimeType: f.mimeType!,
+    size: Number(f.size ?? 0),
+    modifiedTime: f.modifiedTime!,
+  }))
+}
+
+/**
+ * Download a file from Google Drive and return its contents as a Buffer.
+ */
+export async function downloadDriveFile(userId: string, fileId: string): Promise<Buffer> {
+  const drive = await getAuthedDriveClient(userId)
+
+  const res = await drive.files.get(
+    { fileId, alt: 'media' },
+    { responseType: 'arraybuffer' },
+  )
+
+  return Buffer.from(res.data as ArrayBuffer)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,6 +788,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: "npm:^5.1.2"
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: "npm:^7.0.1"
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: "npm:^8.1.0"
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: b1bf42535d49f11dc137f18d5e4e63a28c5569de438a221c369483731e9dac9fb797af554e8bf02b6192d1e5eba6e6402cf93900c3d0ac86391d00d04876789e
+  languageName: node
+  linkType: hard
+
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -1206,6 +1220,13 @@ __metadata:
   version: 1.39.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.39.0"
   checksum: 1a8cc16e83ccd80aeb910e78146e8cde8482ac45feb3693348eec5983d8ad254f977f2b61db76f043ab0fa6009a27df610a9cff286a217d6cd4c114216861d0f
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
   languageName: node
   linkType: hard
 
@@ -3018,12 +3039,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.1.0":
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: 9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^6.0.1":
+  version: 6.2.2
+  resolution: "ansi-regex@npm:6.2.2"
+  checksum: 05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
     color-convert: "npm:^2.0.1"
   checksum: 895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
   languageName: node
   linkType: hard
 
@@ -3240,7 +3282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
@@ -3363,6 +3405,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bignumber.js@npm:^9.0.0":
+  version: 9.3.1
+  resolution: "bignumber.js@npm:9.3.1"
+  checksum: 61342ba5fe1c10887f0ecf5be02ff6709271481aff48631f86b4d37d55a99b87ce441cfd54df3d16d10ee07ceab7e272fc0be430c657ffafbbbf7b7d631efb75
+  languageName: node
+  linkType: hard
+
 "bindings@npm:^1.5.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
@@ -3432,6 +3481,13 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 545a5fa9d7234e3777a7177ec1e9134bb2ba60a69e6b95683f6982b1473aad347c77c1264ccf2ac5dea609a9731fbfbda6b85782bdca70f80f86e28a402504bd
+  languageName: node
+  linkType: hard
+
+"buffer-equal-constant-time@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "buffer-equal-constant-time@npm:1.0.1"
+  checksum: fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
   languageName: node
   linkType: hard
 
@@ -3822,6 +3878,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-uri-to-buffer@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "data-uri-to-buffer@npm:4.0.1"
+  checksum: 20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
+  languageName: node
+  linkType: hard
+
 "data-view-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-buffer@npm:1.0.2"
@@ -4032,6 +4095,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
+"ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "ecdsa-sig-formatter@npm:1.0.11"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
+  languageName: node
+  linkType: hard
+
 "effect@npm:3.18.4":
   version: 3.18.4
   resolution: "effect@npm:3.18.4"
@@ -4046,6 +4125,13 @@ __metadata:
   version: 1.5.302
   resolution: "electron-to-chromium@npm:1.5.302"
   checksum: 014413f2b4ec3a0e043c68f6c07a760d230b14e36b8549c5b124f386a6318d9641e69be2aa0df1877395dd99922745c1722c8ecb3d72205f0f3b3b3dc44c8442
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "emoji-regex@npm:8.0.0"
+  checksum: b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
   languageName: node
   linkType: hard
 
@@ -4624,6 +4710,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: 73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
+  languageName: node
+  linkType: hard
+
 "fast-check@npm:^3.23.1":
   version: 3.23.2
   resolution: "fast-check@npm:3.23.2"
@@ -4685,6 +4778,16 @@ __metadata:
     picomatch:
       optional: true
   checksum: e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
+"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
+  version: 3.2.0
+  resolution: "fetch-blob@npm:3.2.0"
+  dependencies:
+    node-domexception: "npm:^1.0.0"
+    web-streams-polyfill: "npm:^3.0.3"
+  checksum: 60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
   languageName: node
   linkType: hard
 
@@ -4759,7 +4862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:3.3.1":
+"foreground-child@npm:3.3.1, foreground-child@npm:^3.1.0":
   version: 3.3.1
   resolution: "foreground-child@npm:3.3.1"
   dependencies:
@@ -4779,6 +4882,15 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+  languageName: node
+  linkType: hard
+
+"formdata-polyfill@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "formdata-polyfill@npm:4.0.10"
+  dependencies:
+    fetch-blob: "npm:^3.1.2"
+  checksum: 5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
   languageName: node
   linkType: hard
 
@@ -4849,6 +4961,29 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 33e77fd29bddc2d9bb78ab3eb854c165909201f88c75faa8272e35899e2d35a8a642a15e7420ef945e1f64a9670d6aa3ec744106b2aa42be68ca5114025954ca
+  languageName: node
+  linkType: hard
+
+"gaxios@npm:^7.0.0, gaxios@npm:^7.0.0-rc.4":
+  version: 7.1.3
+  resolution: "gaxios@npm:7.1.3"
+  dependencies:
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^7.0.1"
+    node-fetch: "npm:^3.3.2"
+    rimraf: "npm:^5.0.1"
+  checksum: a4a1cdf9a392c0c22e9734a40dca5a77a2903f505b939a50f1e68e312458b1289b7993d2f72d011426e89657cae77a3aa9fc62fb140e8ba90a1faa31fdbde4d2
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^8.0.0":
+  version: 8.1.2
+  resolution: "gcp-metadata@npm:8.1.2"
+  dependencies:
+    gaxios: "npm:^7.0.0"
+    google-logging-utils: "npm:^1.0.0"
+    json-bigint: "npm:^1.0.0"
+  checksum: 15a61231a9410dc11c2828d2c9fdc8b0a939f1af746195c44edc6f2ffea0acab52cef3a7b9828069a36fd5d68bda730f7328a415fe42a01258f6e249dfba6908
   languageName: node
   linkType: hard
 
@@ -4981,6 +5116,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^10.3.7":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
+  languageName: node
+  linkType: hard
+
 "glob@npm:^13.0.0":
   version: 13.0.6
   resolution: "glob@npm:13.0.6"
@@ -5016,6 +5167,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^10.1.0, google-auth-library@npm:^10.2.0":
+  version: 10.5.0
+  resolution: "google-auth-library@npm:10.5.0"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    gaxios: "npm:^7.0.0"
+    gcp-metadata: "npm:^8.0.0"
+    google-logging-utils: "npm:^1.0.0"
+    gtoken: "npm:^8.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 49d3931d20b1f4a4d075216bf5518e2b3396dcf441a8f1952611cf3b6080afb1261c3d32009609047ee4a1cc545269a74b4957e6bba9cce840581df309c4b145
+  languageName: node
+  linkType: hard
+
+"google-logging-utils@npm:^1.0.0":
+  version: 1.1.3
+  resolution: "google-logging-utils@npm:1.1.3"
+  checksum: e65201c7e96543bd1423b9324013736646b9eed60941e0bfa47b9bfd146d2f09cf3df1c99ca60b7d80a726075263ead049ee72de53372cb8458c3bc55c2c1e59
+  languageName: node
+  linkType: hard
+
+"googleapis-common@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "googleapis-common@npm:8.0.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+    gaxios: "npm:^7.0.0-rc.4"
+    google-auth-library: "npm:^10.1.0"
+    qs: "npm:^6.7.0"
+    url-template: "npm:^2.0.8"
+  checksum: ee939fdfcaea32c528e7be64621b3e6b35e612f2456c8d4aca835e0a01ccec52f4ea2ac9509b083128398631a6cd66512c400adb4d0375a4638c55888ccdea7f
+  languageName: node
+  linkType: hard
+
+"googleapis@npm:^171.4.0":
+  version: 171.4.0
+  resolution: "googleapis@npm:171.4.0"
+  dependencies:
+    google-auth-library: "npm:^10.2.0"
+    googleapis-common: "npm:^8.0.0"
+  checksum: cc7c253767b5b425971c4abe0527ca06cebe266a4a7c546813393f831dac19b7568bc317f71fb11b30fea57ed6dc43adb262c74581a91463d84742ccdbaf0c8a
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1, gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
@@ -5041,6 +5237,16 @@ __metadata:
   version: 1.1.1
   resolution: "graphmatch@npm:1.1.1"
   checksum: 98570352e8e62f5e18e397fb9a1ca90a31f18c46240529d5f9ee0020efa3642857337643ae731bd2667957821956dc315badc98243db284d7e5c76aedcf49b4d
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "gtoken@npm:8.0.0"
+  dependencies:
+    gaxios: "npm:^7.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 058538e5bbe081d30ada5f1fd34d3a8194357c2e6ecbf7c8a98daeefbf13f7e06c15649c7dace6a1d4cc3bc6dc5483bd484d6d7adc5852021896d7c05c439f37
   languageName: node
   linkType: hard
 
@@ -5379,6 +5585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-fullwidth-code-point@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-fullwidth-code-point@npm:3.0.0"
+  checksum: bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
+  languageName: node
+  linkType: hard
+
 "is-generator-function@npm:^1.0.10":
   version: 1.1.2
   resolution: "is-generator-function@npm:1.1.2"
@@ -5572,6 +5785,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^3.1.2":
+  version: 3.4.3
+  resolution: "jackspeak@npm:3.4.3"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 6acc10d139eaefdbe04d2f679e6191b3abf073f111edf10b1de5302c97ec93fffeb2fdd8681ed17f16268aa9dd4f8c588ed9d1d3bffbbfa6e8bf897cbb3149b9
+  languageName: node
+  linkType: hard
+
 "javascript-natural-sort@npm:^0.7.1":
   version: 0.7.1
   resolution: "javascript-natural-sort@npm:0.7.1"
@@ -5619,6 +5845,15 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: 531779df5ec94f47e462da26b4cbf05eb88a83d9f08aac2ba04206508fc598527a153d08bd462bae82fc78b3eaa1a908e1a4a79f886e9238641c4cdefaf118b1
+  languageName: node
+  linkType: hard
+
+"json-bigint@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-bigint@npm:1.0.0"
+  dependencies:
+    bignumber.js: "npm:^9.0.0"
+  checksum: e3f34e43be3284b573ea150a3890c92f06d54d8ded72894556357946aeed9877fd795f62f37fe16509af189fd314ab1104d0fd0f163746ad231b9f378f5b33f4
   languageName: node
   linkType: hard
 
@@ -5691,6 +5926,27 @@ __metadata:
     readable-stream: "npm:~2.3.6"
     setimmediate: "npm:^1.0.5"
   checksum: 58e01ec9c4960383fb8b38dd5f67b83ccc1ec215bf74c8a5b32f42b6e5fb79fada5176842a11409c4051b5b94275044851814a31076bf49e1be218d3ef57c863
+  languageName: node
+  linkType: hard
+
+"jwa@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
+  dependencies:
+    buffer-equal-constant-time: "npm:^1.0.1"
+    ecdsa-sig-formatter: "npm:1.0.11"
+    safe-buffer: "npm:^5.0.1"
+  checksum: ab3ebc6598e10dc11419d4ed675c9ca714a387481466b10e8a6f3f65d8d9c9237e2826f2505280a739cf4cbcf511cb288eeec22b5c9c63286fc5a2e4f97e78cf
+  languageName: node
+  linkType: hard
+
+"jws@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "jws@npm:4.0.1"
+  dependencies:
+    jwa: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 6be1ed93023aef570ccc5ea8d162b065840f3ef12f0d1bb3114cade844de7a357d5dc558201d9a65101e70885a6fa56b17462f520e6b0d426195510618a154d0
   languageName: node
   linkType: hard
 
@@ -5920,6 +6176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.2.0":
+  version: 10.4.3
+  resolution: "lru-cache@npm:10.4.3"
+  checksum: ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
   version: 11.2.6
   resolution: "lru-cache@npm:11.2.6"
@@ -6073,6 +6336,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^9.0.4":
+  version: 9.0.6
+  resolution: "minimatch@npm:9.0.6"
+  dependencies:
+    brace-expansion: "npm:^5.0.2"
+  checksum: b81984f96b64b9b3c6cc7d949950290c456639bf5d89c568041b0505080cfe34102bd1d8586a4dc65878ca02e68ac425e0d8fcb7af10156694c4b8889a0c6c75
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
@@ -6149,7 +6421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
   checksum: 539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
@@ -6336,6 +6608,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-domexception@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: 5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+  languageName: node
+  linkType: hard
+
 "node-ensure@npm:^0.0.0":
   version: 0.0.0
   resolution: "node-ensure@npm:0.0.0"
@@ -6373,6 +6652,17 @@ __metadata:
     encoding:
       optional: true
   checksum: b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: "npm:^4.0.0"
+    fetch-blob: "npm:^3.1.4"
+    formdata-polyfill: "npm:^4.0.10"
+  checksum: f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
   languageName: node
   linkType: hard
 
@@ -6600,6 +6890,7 @@ __metadata:
     eslint: "npm:^9.0.0"
     eslint-config-next: "npm:^16.2.0-canary.56"
     exa-js: "npm:^2.4.0"
+    googleapis: "npm:^171.4.0"
     jszip: "npm:^3.10.1"
     lucide-react: "npm:^0.400.0"
     mathjs: "npm:^15.1.1"
@@ -6698,6 +6989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
 "pako@npm:~1.0.2":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
@@ -6732,6 +7030,16 @@ __metadata:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
   languageName: node
   linkType: hard
 
@@ -7031,6 +7339,15 @@ __metadata:
   version: 6.1.0
   resolution: "pure-rand@npm:6.1.0"
   checksum: 1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.7.0":
+  version: 6.15.0
+  resolution: "qs@npm:6.15.0"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
   languageName: node
   linkType: hard
 
@@ -7373,6 +7690,17 @@ __metadata:
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
   checksum: 4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^5.0.1":
+  version: 5.0.10
+  resolution: "rimraf@npm:5.0.10"
+  dependencies:
+    glob: "npm:^10.3.7"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 7da4fd0e15118ee05b918359462cfa1e7fe4b1228c7765195a45b55576e8c15b95db513b8466ec89129666f4af45ad978a3057a02139afba1a63512a2d9644cc
   languageName: node
   linkType: hard
 
@@ -7809,6 +8137,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
+  dependencies:
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: ab9c4264443d35b8b923cbdd513a089a60de339216d3b0ed3be3ba57d6880e1a192b70ae17225f764d7adbf5994e9bb8df253a944736c15a0240eff553c678ca
+  languageName: node
+  linkType: hard
+
 "string.prototype.includes@npm:^2.0.1":
   version: 2.0.1
   resolution: "string.prototype.includes@npm:2.0.1"
@@ -7904,6 +8254,24 @@ __metadata:
   dependencies:
     safe-buffer: "npm:~5.1.0"
   checksum: b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
+  languageName: node
+  linkType: hard
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+  checksum: 1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.2
+  resolution: "strip-ansi@npm:7.1.2"
+  dependencies:
+    ansi-regex: "npm:^6.0.1"
+  checksum: 0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
   languageName: node
   linkType: hard
 
@@ -8360,6 +8728,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url-template@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "url-template@npm:2.0.8"
+  checksum: 56a15057eacbcf05d52b0caed8279c8451b3dd9d32856a1fdd91c6dc84dcb1646f12bafc756b7ade62ca5b1564da8efd7baac5add35868bafb43eb024c62805b
+  languageName: node
+  linkType: hard
+
 "use-callback-ref@npm:^1.3.3":
   version: 1.3.3
   resolution: "use-callback-ref@npm:1.3.3"
@@ -8438,6 +8813,13 @@ __metadata:
     d3-time: "npm:^3.0.0"
     d3-timer: "npm:^3.0.1"
   checksum: 0a9628db30b898160409628f26d457ba15adc86472531817d73fbeb847de498d94f91dee5f4caa969195744e91be93e100eeff7a392b591ac5349343a36dec29
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
   languageName: node
   linkType: hard
 
@@ -8552,6 +8934,28 @@ __metadata:
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
   checksum: e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
+  languageName: node
+  linkType: hard
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version: 7.0.0
+  resolution: "wrap-ansi@npm:7.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.1.0"
+    string-width: "npm:^5.0.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 138ff58a41d2f877eae87e3282c0630fc2789012fc1af4d6bd626eeb9a2f9a65ca92005e6e69a75c7b85a68479fe7443c7dbe1eb8fbaa681a4491364b7c55c60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Replace dead-end "Go to Settings" modal with a complete inline 4-step wizard
- **Step 1 (Connect)**: OAuth button inline; popup-based consent flow; auto-advances on completion
- **Step 2 (Browse)**: Folder tree navigation with breadcrumbs and file count preview
- **Step 3 (Select)**: File list with checkboxes, select-all, file size/date display
- **Step 4 (Import)**: Progress indicator, per-file success/error results, "Import More" option
- New Google Drive service layer with encrypted token storage and automatic refresh
- 7 API routes: connect, callback, status, folders, files, import, disconnect
- File deduplication by content hash and Google Drive file ID
- Imported PDF statements auto-processed through existing pipeline

## Test plan
- [ ] Click "Import from Google Drive" → wizard modal opens at Step 1
- [ ] Click "Connect Google Drive" → OAuth popup opens, complete consent
- [ ] Wizard auto-advances to folder browser after OAuth
- [ ] Navigate folders, click "Select files" → file list with checkboxes
- [ ] Select files, click "Import N files" → progress shown, files imported
- [ ] Re-importing same file → deduplicated (skipped)
- [ ] Without `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` → graceful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)