### PR TITLE
feat: add Scenarios page back to navigation

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -7,6 +7,7 @@ import {
   Home,
   Receipt,
   PieChart,
+  TrendingUp,
   FolderOpen,
   MessageSquare,
   Settings,
@@ -32,6 +33,7 @@ const navItems = [
   { href: '/dashboard', label: 'Dashboard', icon: Home },
   { href: '/transactions', label: 'Transactions', icon: Receipt },
   { href: '/expenses', label: 'Expenses', icon: PieChart },
+  { href: '/scenarios', label: 'Scenarios', icon: TrendingUp },
   { href: '/documents', label: 'Documents', icon: FolderOpen },
 ]
 


### PR DESCRIPTION
## Summary
- Adds Scenarios nav item between Expenses and Documents
- Uses TrendingUp icon (matches the scenarios dashboard component)
- Shows in both desktop and mobile menus

Closes NAN-486

## Test plan
- [ ] Scenarios appears in navbar between Expenses and Documents
- [ ] Clicking it navigates to /scenarios
- [ ] Mobile menu also shows Scenarios
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)